### PR TITLE
Completed core transform building blocks

### DIFF
--- a/examples/jstrans/testtemplate2.json
+++ b/examples/jstrans/testtemplate2.json
@@ -2,6 +2,6 @@
     "$schema":  "http://mgi.nist.gov/mgi-json-trans/v0.1",
 
     "type": "stringtemplate",
-    "content": "Contact {contact/name} via <{contact/email}>",
+    "content": "Contact {/contact/name} via <{/contact/email}>",
     "returns": "string"
 }

--- a/examples/jstrans/testtemplate3.json
+++ b/examples/jstrans/testtemplate3.json
@@ -2,6 +2,6 @@
     "$schema":  "http://mgi.nist.gov/mgi-json-trans/v0.1",
 
     "type": "json",
-    "content": "Contact {contact/name} via <{contact/email}>",
+    "content": "Contact {/contact/name} via <{/contact/email}>",
     "returns": "string"
 }

--- a/examples/jstrans/testtemplate4.json
+++ b/examples/jstrans/testtemplate4.json
@@ -5,7 +5,7 @@
     "content": { 
         "contacts": [ 
             {
-                "{contact/name}": "{contact/name} <{contact/email}>"
+                "{/contact/name}": "{/contact/name} <{/contact/email}>"
             }
         ]
     },

--- a/schemas/json/mgi-json-trans.json
+++ b/schemas/json/mgi-json-trans.json
@@ -314,6 +314,52 @@
                 }
             ]
         },
+        "CallableTransform": {
+            "description": "a transform that can be used to turn other Tranform types into transforms that can be called in function form.",
+            "allOf": [
+                { "$ref": "#/definitions/Transform" },
+                { 
+                    "properties": {
+                        "item": {
+                            "enum": ["callable"]
+                        },
+                        "transform": {
+                            "description": "a transform configuration that will provide the implementation for the callable version",
+                            "notes": [
+                            ]
+                        },
+                        "dontpass": {
+                            "description": "a list of array indexes to the argument list provided to the function that should not be passed to the transform",
+                            "notes": [
+                                "This list should correspond to the argument references in the transform configuration.",
+                                "The arguments refered here will not only not be passed to the transform, they will be treated as literals when plugged into the transform configuration--that is, arguments in this set that look like transform invocations or data pointers will not be resolved (although the constructed transform may do that)."
+                            ],
+                            "type": "array",
+                            "items": { "type": "integer" }
+                        },
+                        "pass": {
+                            "description": "a template for the arguments to pass into the transform (constructed from the transform property)",
+                            "notes": [
+                                "This template will be treated like a JSON template (i.e. given as a JSON Transform's content property) and applied to the list of arguments as its input.  The array items that result from this will then be resolved into transforms as appropriate."
+                            ],
+                            "type": "array"
+                        },
+                        "argv_supported": {
+                            "description": "a specification of arguments that can be passed to the transform when invoked in function form",
+                            "notes": [
+                                "if any argument is defined as required, then the transform can only be invoked in function form"
+                            ],
+                            "comments": [
+                                "at the moment, I believe this property is only for documentation purposes"
+                            ],
+                            "type": "array",
+                            "items": { "$ref": "#/definitions/FunctionArg" }
+                        }
+                    },
+                    "required": [ "transform" ]
+                }
+            ]
+        },
         "MapJoinTransform": {
             "description": "a transform that applies a transform on each of elements of an input array and then combines them with a join transform",
             "allOf": [

--- a/schemas/json/mgi-json-trans.json
+++ b/schemas/json/mgi-json-trans.json
@@ -323,26 +323,21 @@
                         "item": {
                             "enum": ["callable"]
                         },
-                        "transform": {
-                            "description": "a transform configuration that will provide the implementation for the callable version",
+                        "transform_tmpl": {
+                            "description": "a JSON template for transform configuration that will provide the implementation for the callable version",
                             "notes": [
-                            ]
-                        },
-                        "dontpass": {
-                            "description": "a list of array indexes to the argument list provided to the function that should not be passed to the transform",
-                            "notes": [
-                                "This list should correspond to the argument references in the transform configuration.",
-                                "The arguments refered here will not only not be passed to the transform, they will be treated as literals when plugged into the transform configuration--that is, arguments in this set that look like transform invocations or data pointers will not be resolved (although the constructed transform may do that)."
                             ],
+                            "type": "object"
+                        },
+                        "conf_args_index": {
+                            "description": "an ordered list of argument indexes for selecting which arguments given to the function should be used to configure the underlying transform at resolve time.",
                             "type": "array",
                             "items": { "type": "integer" }
                         },
-                        "pass": {
-                            "description": "a template for the arguments to pass into the transform (constructed from the transform property)",
-                            "notes": [
-                                "This template will be treated like a JSON template (i.e. given as a JSON Transform's content property) and applied to the list of arguments as its input.  The array items that result from this will then be resolved into transforms as appropriate."
-                            ],
-                            "type": "array"
+                        "args_index": {
+                            "description": "an ordered list of argument indexes for selecting which arguments given to the function should be passed to the underlying transform at transform time",
+                            "type": "array",
+                            "items": { "type": "integer" }
                         },
                         "argv_supported": {
                             "description": "a specification of arguments that can be passed to the transform when invoked in function form",

--- a/schemas/json/mgi-json-trans.json
+++ b/schemas/json/mgi-json-trans.json
@@ -242,10 +242,7 @@
                             "type": "string"
                         },
                         "args": {
-                            "description": "an array that describes how to pass an arguments passed to this transform to the underlying implementation (using $argv directives",
-                            "notes": [
-                                "string items are interpreted as string templates that may contain '{$argv}' directives; all others will be passed in as literal values."
-                            ],
+                            "description": "an array of data to pass as extra arguments to the native implementation",
                             "type": "array"
                         },
                         "argv_supported": {
@@ -264,14 +261,14 @@
                 }
             ]
         },
-        "Pointer": {
+        "ExtractTransform": {
             "description": "",
             "allOf": [
                 { "$ref": "#/definitions/Transform" },
                 { 
                     "properties": {
                         "item": {
-                            "enum": ["pointer"]
+                            "enum": ["extract"]
                         },
                         "select": {
                             "description": "a data pointer to the JSON data to extract from the input.",
@@ -284,6 +281,36 @@
                         }
                     },
                     "required": [ "type", "select" ]
+                }
+            ]
+        },
+        "ApplyTransform": {
+            "description":  "a transform that applies another transform with different data set as the current input data",
+            "allOf": [
+                { "$ref": "#/definitons/Transform" },
+                {
+                    "properties": {
+                        "transform": {
+                            "description": "the name of the transform to apply to the specified input data"
+                        },
+                        "input": {
+                            "description": "a specification of the data to transform",
+                            "notes": [
+                                "The value can be one of several forms for different ways of providing or refering to the input data:",
+                                "a transform object -- a JSON object will be assumed to be an anonymous transform whose out put will be the input to this transform.",
+                                "a transform invoked as a function -- a string that contains an open or closed parenthesis will be assumed to be a functional transform invocation (although an error is raised if the string does not match the function pattern, f(arg, ...).  The output of executing the function will be used as the input to this transform",
+                                "a transform name -- a string that contains only legal characgters used for naming a transform (i.e. excluding (,), and /) will be interpreted as the name of a defined transform that whose output, when invoked, should be used as the input to this transform.",
+                                "a data pointer -- a string that contains a / or does not match to the name of a registered transform is assumed to be a data pointer.  This pointer will be applied to its target (the current document fragment, the context data, or an input argument list) to extract the data to be used as input to this transform.",
+                                "If a value is not provide, the default is $in:, i.e. the current input data."
+                            ],
+                            "default": "$in:"
+                        },
+                        "args": {
+                            "description": "the list of arguments to pass to the transform",
+                            "type": "array"
+                        }
+                    },
+                    "require": [ "transform" ]
                 }
             ]
         },

--- a/schemas/json/mgi-json-trans.json
+++ b/schemas/json/mgi-json-trans.json
@@ -355,14 +355,14 @@
                 }
             ]
         },
-        "MapJoinTransform": {
+        "MapTransform": {
             "description": "a transform that applies a transform on each of elements of an input array and then combines them with a join transform",
             "allOf": [
                 { "$ref": "#/definitions/Transform" },
                 { 
                     "properties": {
                         "item": {
-                            "enum": ["mapjoin"]
+                            "enum": ["map"]
                         },
                         "itemmap": {
                             "description": "the transform to apply to each element of the array",
@@ -376,22 +376,8 @@
                                     "$ref": "#/definitions/Transform"
                                 }
                             ]
-                        },
-                        "join": {
-                            "description": "the transform to apply to the array resulting from the map transform",
-                            "oneOf": [
-                                { 
-                                    "description": "a text-based reference to a transform",
-                                    "type": "string" 
-                                },
-                                {
-                                    "description": "a transform description object",
-                                    "$ref": "#/definitions/Transform"
-                                }
-                            ]
                         }
-                    },
-                    "required": [ "type", "itemmap", "join" ]
+                    }
                 }
             ]
         },

--- a/schemas/json/mgi-json-trans.json
+++ b/schemas/json/mgi-json-trans.json
@@ -13,9 +13,9 @@
             }
         },
         "DataPointer": {
-            "description": "a pointer into JSON data comprised of an optional data target ($in or $context) or prefix, a colon, and a path (a JSON pointer excluding the leading slash)",
+            "description": "a pointer into JSON data comprised of an optional data target ($in or $context) or prefix, a colon, and a JSON pointer",
             "type": "string",
-            "pattern": "^([a-zA-Z0-9_!@#$.]:)?[a-zA-Z0-9_!@#$.]+$"
+            "pattern": "^([a-zA-Z0-9_!@#$.]:)?(/[a-zA-Z0-9_!@#$.]*)*$"
         },
         "Transform": {
             "description": "a configuration of a transform that can be applied to JSON data structures",

--- a/schemas/json/mgi-json-trans.json
+++ b/schemas/json/mgi-json-trans.json
@@ -351,7 +351,7 @@
                             "items": { "$ref": "#/definitions/FunctionArg" }
                         }
                     },
-                    "required": [ "transform" ]
+                    "required": [ "transform_tmpl", "conf_args_index" ]
                 }
             ]
         },

--- a/tools/python/xjs/trans/base.py
+++ b/tools/python/xjs/trans/base.py
@@ -69,7 +69,7 @@ class Transform(object):
                 break
             prop = None
         if prop:
-            engine = Engine(self.config, engine)
+            engine = engine.wrap(self.config)
         self.engine = engine
         self._check_status(config, engine)
         self._func = self.mkfn(config, engine)

--- a/tools/python/xjs/trans/engine.py
+++ b/tools/python/xjs/trans/engine.py
@@ -60,7 +60,7 @@ class DataPointer(object):
 
         data_pointer := target ':' json_pointer
         target := prefix | resolved_target
-        resolved_target := '$' ( 'in' | 'context' | 'argv' )
+        resolved_target := '$' ( 'in' | 'context' )
         """
         parts = strrep.strip().rsplit(':')
         if len(parts) > 2:
@@ -406,7 +406,7 @@ class Engine(object):
                                      None, the engine's default context will 
                                      be used.
         """
-        resolved_targets = ("$in", "$context", "$argv")
+        resolved_targets = ("$in", "$context")
 
         if isinstance(dptr, DataPointer):
             out = dptr.copy()
@@ -438,19 +438,14 @@ class Engine(object):
 
         try:
             if use.target == "$in":
-                return jsonptr.extract(input, "/"+use.path)
+                return jsonptr.extract(input, use.path)
             elif use.target == "$context":
-                return jsonptr.extract(context, "/"+use.path)
+                return jsonptr.extract(context, use.path)
         except jsonptr.ExtractError, ex:
             raise DataExtractionError.due_to(ex, input, context)
         except Exception, ex:
-            raise StylesheetContentError("Data pointer (" + str(self) + 
-                                        " does not normalize to useable JSON " +
-                                         "pointer: /" + use.path)
+            raise DataPointerError.due_to(ex, use, select)
 
-        raise StylesheetContentError("Unresolvable prefix: " + use.target)
-
-        return select.extract_from(input, context, self)
 
     def wrap(self, transconfig):
         """

--- a/tools/python/xjs/trans/engine.py
+++ b/tools/python/xjs/trans/engine.py
@@ -104,7 +104,7 @@ class Engine(object):
     """
     A class that represents the driver for applying transformations.
 
-    It includes a built in registry of transforms (and templates and joins) 
+    It includes a built-in registry of transforms (and templates and joins) 
     and prefix defintions which can be retrieved by name.  The available 
     transforms and prefixes can change depending on the current depth within
     a transform (stylesheet).  To facilitate this, an Engine can wrap another 

--- a/tools/python/xjs/trans/exceptions.py
+++ b/tools/python/xjs/trans/exceptions.py
@@ -1,6 +1,7 @@
 """
 Exceptions that can occur while using trans transformations
 """
+import jsonspec.pointer as jsonptr
 
 class JSONTransformException(Exception):
     """
@@ -271,6 +272,33 @@ class DataExtractionError(TransformApplicationException):
         basemsg += "problem extracting data"
         msg = cls.make_message_from_cause(cause, basemsg=basemsg)
         return DataExtractionError(msg, input, context, name, cause)
+
+class DataPointerError(DataExtractionError):
+    """
+    an error indicating a failure extracting data due to a problem with the
+    data pointer itself.  Typically, this is because the pointer does not 
+    follow the proper syntax.
+    """
+
+    @classmethod
+    def due_to(cls, cause, dp, orig=None):
+        """
+        construct an exception that is mainly due to an underlying problem.
+
+        :argument Exception cause:  the exception representing the underlying 
+                                      cause of the exception.  
+        :argument dp:  the (normalized) data pointer
+        :argument orig:  the unnormalized data pointer, if known
+        """
+        causemsg = str(cause)
+        if isinstance(cause, jsonptr.ParseError):
+            causemsg = "did not normalize to useable JSON pointer"
+        msg = "Problem using data pointer"
+        if orig:
+            msg += ", '"+str(orig)+"'"
+        msg += ": {0}: {1}".format(causemsg, str(dp))
+        return DataPointerError(msg, cause=cause)
+        
 
 class TransformInputTypeError(TransformApplicationException):
     """

--- a/tools/python/xjs/trans/transforms/std.py
+++ b/tools/python/xjs/trans/transforms/std.py
@@ -99,7 +99,7 @@ class StringTemplate(Transform):
                     except TransformNotFound:
                         # it's a pointer
                         item = Extract({ "select": item }, self.engine, 
-                                       self.name+":(select)", "pointer")
+                                       self.name+":(select)", "extract")
                     parsed[i] = item
 
         return parsed
@@ -131,7 +131,11 @@ class JSON(Transform):
                     return self.engine.make_transform(skel["$val"], 
                                                       self.name+".(anon)")
                 else:
-                    return self.engine.resolve_transform(skel["$val"])
+                    try:
+                        return self.engine.resolve_transform(skel["$val"])
+                    except TransformNotFound:
+                        return Extract({"select": skel["$val"]}, self.engine,
+                                       self.name+":(select)", "extract")
             else:
                 self._resolve_json_object(skel)
         elif (isinstance(skel, str) or isinstance(skel, unicode)) and \

--- a/tools/python/xjs/trans/transforms/std.py
+++ b/tools/python/xjs/trans/transforms/std.py
@@ -237,7 +237,7 @@ class Extract(Transform):
     def mkfn(self, config, engine):
         select = config.get("select", '')
         def impl(input, context, *args, **keys):
-            return extract(engine, input, context, select)
+            return engine.extract(input, context, select)
         return impl
 
 class MapJoin(Transform):
@@ -461,7 +461,8 @@ types = { "literal": Literal,
           "native": Native,
           "mapjoin": MapJoin,
           "json": JSON,
-          "extract": Extract
+          "extract": Extract,
+          "apply": Apply
           }
 
 # function type implementations

--- a/tools/python/xjs/trans/transforms/std.py
+++ b/tools/python/xjs/trans/transforms/std.py
@@ -395,10 +395,9 @@ class Function(Transform):
             raise TransformConfigTypeError("transform", "str", 
                                            type(config['transform']), self._name)
 
-        uargs = self._build_args(wrapped, args, engine)
-
-        args_index = []
+        uargs = args
         if isinstance(wrapped, Callable):
+            uargs = self._build_args(wrapped, args, engine)
             args_index = wrapped.args_index
             wrapped = self._wrap_callable(wrapped, args, engine)
 

--- a/tools/python/xjs/trans/transforms/std.py
+++ b/tools/python/xjs/trans/transforms/std.py
@@ -231,6 +231,17 @@ class JSON(Transform):
 
         return out
 
+class Extract(Transform):
+    """
+    a transform that extracts data from the input via a data pointer
+    """
+
+    def mkfn(self, config, engine):
+        select = config.get("select", '')
+        def impl(input, context, *args, **keys):
+            return extract(engine, input, context, select)
+        return impl
+
 
 
 class MapJoin(Transform):
@@ -252,17 +263,6 @@ class MapJoin(Transform):
         def impl(input, context, *args, **keys):
             items = map(lambda i: itemmap(engine, i, context), input)
             return join(engine, items, context)
-        return impl
-
-class Extract(Transform):
-    """
-    a transform that extracts data from the input via a data pointer
-    """
-
-    def mkfn(self, config, engine):
-        select = config.get("select", '')
-        def impl(input, context, *args, **keys):
-            return extract(engine, input, context, select)
         return impl
 
 class Native(Transform):

--- a/tools/python/xjs/trans/transforms/std_ss.json
+++ b/tools/python/xjs/trans/transforms/std_ss.json
@@ -14,6 +14,53 @@
             "value": "}",
             "expects": ["any"],
             "returns": "string"
+        },
+        "tostr": {
+            "$extensionSchemas": [ "http://mgi.nist.gov/mgi-json-trans/v0.1#/definitions/NativeTransform" ],
+            "type": "native",
+            "impl": "$std.tostr",
+            "description": "convert input data to a string",
+            "argv_supported": [
+                {
+                    "name": "data",
+                    "description": "the data to convert (default: the current input data)",
+                    "type": "any"
+                }
+            ],
+            "expects": ["any"],
+            "returns": "string"
+        },
+        "indent": {
+            "$extensionSchemas": [ "http://mgi.nist.gov/mgi-json-trans/v0.1#/definitions/NativeTransform" ],
+            "type": "native",
+            "impl": "$std.indent",
+            "description": "prepend a specified number of spaces in front of the input text.",
+            "argv_supported": [
+                {
+                    "name": "indlen",
+                    "description": "the number of spaces to insert at the front of the text",
+                    "type": "string"
+                },
+                {
+                    "name": "data",
+                    "description": "the data to indent (default: the current input data)",
+                    "type": "any"
+                }
+            ],
+            "expects": ["string"],
+            "returns": "string"
+        },
+        "fill": {
+            "type": "apply",
+            "transform": "newline",
+            "input": {
+                "type": "apply",
+                "transform": {
+                    "type": "map",
+                    "itemmap": "indent(5)"
+                },
+                "input": "wrap(70)"
+            }
         }
     },
     "transforms": {
@@ -59,6 +106,23 @@
             "expects": ["any"],
             "returns": "any"
         },
+        "map": {
+            "$extensionSchemas": [ "http://mgi.nist.gov/mgi-json-trans/v0.1#/definitions/CallableTransform" ],
+            "type": "callable",
+            "transform_tmpl": {
+                "type": "map",
+                "itemmap": { "$val": "/0" }
+            },
+            "conf_args_index": [ 0 ],
+            "argv_supported": [
+                {
+                    "name": "itemmap",
+                    "type": "string"
+                }
+            ],
+            "expects": ["array"],
+            "returns": "array"            
+        },
         "wrap": {
             "$extensionSchemas": [ "http://mgi.nist.gov/mgi-json-trans/v0.1#/definitions/NativeTransform" ],
             "type": "native",
@@ -69,20 +133,15 @@
                     "name": "maxlen",
                     "description": "the maximum length of a line in number of characters",
                     "type": "integer"
+                },
+                {
+                    "name": "text",
+                    "description": "the text to break up (default: the current input data)",
+                    "type": "string"
                 }
             ],
             "expects": ["string"],
             "returns": "array"
-        },
-        "fill": {
-            "type": "chain",
-            "status": "disabled",
-            "steps": [
-                "wrap({0})", "newline"
-            ],
-            "argdesc": [ "int: maximum length of each line" ],
-            "expects": ["string"],
-            "returns": "string"
         }
     }, 
     "joins": {

--- a/tools/python/xjs/trans/transforms/std_ss.json
+++ b/tools/python/xjs/trans/transforms/std_ss.json
@@ -42,9 +42,13 @@
             "returns": "any"
         },
         "extract": {
-            "$extensionSchemas": [ "http://mgi.nist.gov/mgi-json-trans/v0.1#/definitions/NativeTransform" ],
-            "type": "native",
-            "impl": "$std.extract",
+            "$extensionSchemas": [ "http://mgi.nist.gov/mgi-json-trans/v0.1#/definitions/CallableTransform" ],
+            "type": "callable",
+            "transform_tmpl": {
+                "type": "extract",
+                "select": { "$val": "/0" }
+            },
+            "conf_args_index": [ 0 ],
             "argv_supported": [
                 {
                     "required": true,

--- a/tools/python/xjs/trans/transforms/tests/test_std.py
+++ b/tools/python/xjs/trans/transforms/tests/test_std.py
@@ -70,7 +70,7 @@ class TestJSON(object):
 
     def test_tmpl4(self, engine):
         config = { "content":  { "a": [True, "[{$lb}{$rb}]", 3],
-                                 "b": { "$val": "numbers" } }    }
+                                 "b": { "$val": "/numbers" } }    }
         transf = std.JSON(config, engine, "goob", "json")
         out = transf({"numbers": range(3)}, {})
         assert isinstance(out, dict)
@@ -84,7 +84,7 @@ class TestJSON(object):
 class TestApply(object):
 
     def test_anon(self, engine):
-        config = { "transform": { "type": "extract", "select": "contact/name" },
+        config = { "transform": { "type": "extract", "select": "/contact/name" },
                    "input": { "type": "json", 
                               "content": { "contact": { "name": "bob" } }} }
         transf = std.Apply(config, engine, "goob", "apply")
@@ -92,7 +92,7 @@ class TestApply(object):
         assert out == "bob"
 
     def test_tname(self, engine):
-        config = { "transform": { "type": "extract", "select": "contact/name",
+        config = { "transform": { "type": "extract", "select": "/contact/name",
                                   "transforms": {
                                      "contactname": {"type": "json", 
                               "content": { "contact": { "name": "bob" } }} }
@@ -103,21 +103,21 @@ class TestApply(object):
         assert out == "bob"
 
     def test_datapointer(self, engine):
-        config = { "transform": { "type": "extract", "select": "name" },
-                   "input": "curation/contact" }
+        config = { "transform": { "type": "extract", "select": "/name" },
+                   "input": "/curation/contact" }
         transf = std.Apply(config, engine, "goob", "apply")
         out = transf({"curation": { "contact": { "name": "bob" }} }, {})
         assert out == "bob"
 
     def test_datapointer2(self, engine):
-        config = { "transform": { "type": "extract", "select": "contact/name" },
-                   "input": "curation" }
+        config = { "transform": { "type": "extract", "select": "/contact/name" },
+                   "input": "/curation" }
         transf = std.Apply(config, engine, "goob", "apply")
         out = transf({"curation": { "contact": { "name": "bob" }} }, {})
         assert out == "bob"
 
     def test_function(self, engine):
-        config = { "transform": { "type": "extract", "select": "0" },
+        config = { "transform": { "type": "extract", "select": "" },
                    "input": "delimit(' and ')" }
         transf = std.Apply(config, engine, "goob", "apply")
         out = transf(["neil", "jack", "me"], {})

--- a/tools/python/xjs/trans/transforms/tests/test_std.py
+++ b/tools/python/xjs/trans/transforms/tests/test_std.py
@@ -81,6 +81,52 @@ class TestJSON(object):
         assert isinstance(out['b'], list)
         assert out['b'][2] is 2
 
+class TestApply(object):
+
+    def test_anon(self, engine):
+        config = { "transform": { "type": "extract", "select": "contact/name" },
+                   "input": { "type": "json", 
+                              "content": { "contact": { "name": "bob" } }} }
+        transf = std.Apply(config, engine, "goob", "apply")
+        out = transf({}, {})
+        assert out == "bob"
+
+    def test_tname(self, engine):
+        config = { "transform": { "type": "extract", "select": "contact/name",
+                                  "transforms": {
+                                     "contactname": {"type": "json", 
+                              "content": { "contact": { "name": "bob" } }} }
+                                  },
+                   "input": "contactname" }
+        transf = std.Apply(config, engine, "goob", "apply")
+        out = transf({}, {})
+        assert out == "bob"
+
+    def test_datapointer(self, engine):
+        config = { "transform": { "type": "extract", "select": "name" },
+                   "input": "curation/contact" }
+        transf = std.Apply(config, engine, "goob", "apply")
+        out = transf({"curation": { "contact": { "name": "bob" }} }, {})
+        assert out == "bob"
+
+    def test_datapointer2(self, engine):
+        config = { "transform": { "type": "extract", "select": "contact/name" },
+                   "input": "curation" }
+        transf = std.Apply(config, engine, "goob", "apply")
+        out = transf({"curation": { "contact": { "name": "bob" }} }, {})
+        assert out == "bob"
+
+    def test_function(self, engine):
+        config = { "transform": { "type": "extract", "select": "0" },
+                   "input": "delimit(' and ')" }
+        transf = std.Apply(config, engine, "goob", "apply")
+        out = transf(["neil", "jack", "me"], {})
+        assert out == "neil and jack and me"
+
+
+
+
+
 
 class TestFunctionTransform(object):
 

--- a/tools/python/xjs/trans/transforms/tests/test_std.py
+++ b/tools/python/xjs/trans/transforms/tests/test_std.py
@@ -44,6 +44,43 @@ class TestStringTemplate(object):
         assert out == "neil and jack and me"
 
 
+class TestJSON(object):
+
+    def test_tmpl1(self, engine):
+        config = { "content": "{$lb}" }
+        transf = std.JSON(config, engine, "goob", "json")
+        out = transf({}, {})
+        assert out == "{"
+
+    def test_tmpl2(self, engine):
+        config = { "content": 4 }
+        transf = std.JSON(config, engine, "goob", "json")
+        out = transf({}, {})
+        assert out == 4
+
+    def test_tmpl3(self, engine):
+        config = { "content":  [ True, "[{$lb}{$rb}]", 3]}
+        transf = std.JSON(config, engine, "goob", "json")
+        out = transf({}, {})
+        assert isinstance(out, list)
+        assert len(out) == 3
+        assert out[0] is True
+        assert out[1] == "[{}]"
+        assert out[2] is 3
+
+    def test_tmpl4(self, engine):
+        config = { "content":  { "a": [True, "[{$lb}{$rb}]", 3],
+                                 "b": { "$val": "numbers" } }    }
+        transf = std.JSON(config, engine, "goob", "json")
+        out = transf({"numbers": range(3)}, {})
+        assert isinstance(out, dict)
+        assert len(out) == 2
+        assert out['a'][0] is True
+        assert out['a'][1] == "[{}]"
+        assert out['a'][2] is 3
+        assert isinstance(out['b'], list)
+        assert out['b'][2] is 2
+
 
 class TestFunctionTransform(object):
 

--- a/tools/python/xjs/trans/transforms/tests/test_std.py
+++ b/tools/python/xjs/trans/transforms/tests/test_std.py
@@ -7,6 +7,7 @@ engine = object()
 import xjs.trans.transforms.std as std
 from xjs.validate import ExtValidator
 from xjs.trans.engine import StdEngine
+from xjs.trans.exceptions import *
 
 def test_literal():
 
@@ -132,14 +133,151 @@ class TestExtractTransform(object):
         out = transf({"curation": { "contact": { "name": "bob" }} }, {})
         assert out == 'bob'
 
+    def test_transform_a(self, engine):
+        config = { "select": "/2" }
+        transf = std.Extract(config, engine, 'goob', "apply")
+        out = transf(["neil", "jack", "me"], {})
+        assert out == "me"
+
+    def test_transform_a2(self, engine):
+        config = { "select": "" }
+        transf = std.Extract(config, engine, 'goob', "apply")
+        out = transf(["neil", "jack", "me"], {})
+        assert isinstance(out, list)
+        assert out[1] == "jack"
+        assert len(out) == 3
+
     def test_function(self, engine):
         config = { "content": "Call {extract(/curation/contact/name)}." }
         transf = std.StringTemplate(config, engine, "goob", "stringtemplate")
         out = transf({"curation": { "contact": { "name": "bob" }} }, {})
         assert out == 'Call bob.'
 
+def test_tostr(engine):
+    assert std.tostr(engine, {}, {}, True) == "true"
+    assert std.tostr(engine, {}, {}, [ 1, 2, 3 ]) == "[1, 2, 3]"
+    assert std.tostr(engine, {}, {}, "glub") == "glub"
+    assert std.tostr(engine, True, {}) == "true"
+    assert std.tostr(engine, [ 1, 2, 3 ], {}) == "[1, 2, 3]"
+
+    transf = engine.resolve_transform("tostr")
+    assert transf(True, {}) == "true"
+    assert transf([ 1, 2, 3 ], {}) == "[1, 2, 3]"
+    assert transf(False, {}, True) == "true"
+
+    transf = engine.resolve_transform("tostr()")
+    assert transf(True, {}) == "true"
+    transf = engine.resolve_transform("tostr([ 1, 2, 3 ])")
+    assert transf(True, {}) == "[1, 2, 3]"
+
+    # note: can't convert True, False, or None.
+
+def test_wrap(engine):
+
+    text = "convert a paragraph of text into an array of strings broken at word boundarys that are less than a given maximum in length.  "
+    split = std.wrap(engine, text, None)
+    assert isinstance(split, list)
+    assert len(split) == 2
+    assert len(split[0]) <= 75
+    assert len(split[1]) <= 75
+    assert split[0] == "convert a paragraph of text into an array of strings broken at word"
+    assert split[1] == "boundarys that are less than a given maximum in length."
+
+    split = std.wrap(engine, text, None, 45)
+    assert isinstance(split, list)
+    assert len(split) == 3
+    assert len(split[0]) <= 45
+    assert len(split[1]) <= 45
+    assert len(split[2]) <= 45
+    assert split[0] == "convert a paragraph of text into an array of"
+    assert split[1] == "strings broken at word boundarys that are"
+    assert split[2] == "less than a given maximum in length."    
+
+    split = std.wrap(engine, "Yeah, man!", None)
+    assert isinstance(split, list)
+    assert len(split) == 1
+    assert split[0] == "Yeah, man!"
+
+    split = std.wrap(engine, text, None, 40, "Yeah, man!")
+    assert isinstance(split, list)
+    assert len(split) == 1
+    assert split[0] == "Yeah, man!"
+
+    transf = engine.resolve_transform("wrap(75)")
+    split = transf(text, None)
+    assert isinstance(split, list)
+    assert len(split) == 2
+    assert len(split[0]) <= 75
+    assert len(split[1]) <= 75
+    assert split[0] == "convert a paragraph of text into an array of strings broken at word"
+    assert split[1] == "boundarys that are less than a given maximum in length."
+    
+    transf = engine.resolve_transform("wrap(75, 'Yeah, man!')")
+    split = transf(text, None)
+    assert len(split) == 1
+    assert split[0] == "Yeah, man!"
+
+    config = { "type": "apply",
+               "transform": "wrap",
+               "args": [ 45 ] }
+    transf = engine.make_transform(config)
+    split = transf(text, None)
+    assert len(split) == 3
+    assert len(split[0]) <= 45
+    assert len(split[1]) <= 45
+    assert len(split[2]) <= 45
+    assert split[0] == "convert a paragraph of text into an array of"
+    assert split[1] == "strings broken at word boundarys that are"
+    assert split[2] == "less than a given maximum in length."    
+
+def test_indent(engine):
+    
+    out = std.indent(engine, "Yah!", None, 8)
+    assert out == "        Yah!"
+    out = std.indent(engine, "Yah!", None, 6, "boo!")
+    assert out == "      boo!"
+
+    transf = engine.resolve_transform("indent")
+    assert transf("goob", {}) == "    goob"
+    
+
+class TestMap(object):
+
+    def test_basic(self, engine):
+        config = { "itemmap": "indent(4)" }
+        transf = std.Map(config, engine, 'goob', "apply")
+        out = transf(["neil", "jack", "me"], None)
+        assert out == ["    neil", "    jack", "    me"]
+
+    def test_unstrict(self, engine):
+        config = { "itemmap": "indent(4)" }
+        transf = std.Map(config, engine, 'goob', "apply")
+        out = transf("neil", None)
+        assert out == ["    neil"]
+
+    def test_strict(self, engine):
+        config = { "itemmap": "indent(4)", "strict": True }
+        transf = std.Map(config, engine, 'goob', "apply")
+        with pytest.raises(TransformInputTypeError):
+            out = transf("neil", None)
+
+    def test_function(self, engine):
+        config = { "content": "Call {map(indent(4))}." }
+        transf = std.StringTemplate(config, engine, "goob", "stringtemplate")
+        out = transf(["neil", "jack", "me"], None)
+        assert out == 'Call ["    neil", "    jack", "    me"].'
 
 
+def test_fill(engine):
+
+    text = "convert a paragraph of text into an array of strings broken at word boundarys that are less than a given maximum in length.  "
+    config = { "type": "apply", "transform": "fill" }
+    transf = engine.make_transform(config)
+    #pytest.set_trace()
+    out = transf(text, None)
+    assert out == "     convert a paragraph of text into an array of strings broken at word\n     boundarys that are less than a given maximum in length."
+
+    
 
 class TestFunctionTransform(object):
 

--- a/tools/python/xjs/trans/transforms/tests/test_std.py
+++ b/tools/python/xjs/trans/transforms/tests/test_std.py
@@ -124,6 +124,19 @@ class TestApply(object):
         assert out == "neil and jack and me"
 
 
+class TestExtractTransform(object):
+
+    def test_transform(self, engine):
+        config = { "select": "/curation/contact/name" }
+        transf = std.Extract(config, engine, 'goob', "apply")
+        out = transf({"curation": { "contact": { "name": "bob" }} }, {})
+        assert out == 'bob'
+
+    def test_function(self, engine):
+        config = { "content": "Call {extract(/curation/contact/name)}." }
+        transf = std.StringTemplate(config, engine, "goob", "stringtemplate")
+        out = transf({"curation": { "contact": { "name": "bob" }} }, {})
+        assert out == 'Call bob.'
 
 
 


### PR DESCRIPTION
This merge completes the basic core capabilities for defining and combining transforms.  In particular,
- fixed data pointers: make path portion an explicit JSON pointer (see 5ef2b50)
- add new Transform types: Apply, Map, and Callable; updated Function to support Callable
- added new standard transforms:  tostr, indent, wrap, fill, apply; improved extract
