### PR TITLE
Version 0.8: DataCite alignment and extendable roles/types

### DIFF
--- a/examples/xml/ipr-test.xml
+++ b/examples/xml/ipr-test.xml
@@ -80,6 +80,10 @@
      <propertyClass> simulated </propertyClass>
      <propertyClass> structural </propertyClass>
    </applicability>
+   <related>
+     <relationship xsi:type="dcr:DciteRelation" label="IsDocumentedBy"> is documented by </relationship>
+     <resource>IPR Help Page</resource>
+   </related>
    <access>
      <policy><rights> public </rights></policy>
      <portal>

--- a/examples/xml/ipr-test.xml
+++ b/examples/xml/ipr-test.xml
@@ -18,7 +18,7 @@
      </publisher>
      <publicationYear> 2014 </publicationYear>
      <creator>
-       <name>Chandler Becker</name>
+       <name pid="orcid:09834100891">Chandler Becker</name>
        <affiliation> NIST </affiliation>
      </creator>
      <creator>
@@ -27,7 +27,7 @@
        </name>
      </creator>
      <contributor role="DataCurator" xsi:type="dcr:DciteContributor">
-       <name>Zachary Trautt</name>
+       <name pid="orcid:09834100891">Zachary Trautt</name>
      </contributor>
      <date role="Created" xsi:type="dcr:DciteDate"> 2008-04-01 </date>
      <contact>

--- a/examples/xml/ipr-test.xml
+++ b/examples/xml/ipr-test.xml
@@ -8,6 +8,7 @@
 
    <identity>
      <title>The Interatomic Potentials Repository Project</title>
+     <altTitle type="AlternativeTitle">The Interatomic Potentials Repository Project</altTitle>
      <shortName> IPR </shortName>
      <version>2.0</version>
    </identity>
@@ -15,9 +16,20 @@
      <publisher> 
        NIST/MSED Center for Theoretical and Computational Materials Science (CTCMS) 
      </publisher>
-     <creator> Chandler Becker </creator>
-     <contributor> Zachary Trautt </contributor>
-     <date role="Created" xsi:type="dcr:TypedDate"> 2008-04-01 </date>
+     <publicationYear> 2014 </publicationYear>
+     <creator>
+       <name>Chandler Becker</name>
+       <affiliation> NIST </affiliation>
+     </creator>
+     <creator>
+       <name sur="van Der Graaf" given="Hans">
+         Hans van Der Graaf
+       </name>
+     </creator>
+     <contributor role="DataCurator" xsi:type="dcr:DciteContributor">
+       <name>Zachary Trautt</name>
+     </contributor>
+     <date role="Created" xsi:type="dcr:DciteDate"> 2008-04-01 </date>
      <contact>
        <name>Zachary Trautt</name>
        <emailAddress> zachary.trautt@nist.gov </emailAddress>

--- a/examples/xml/ipr-test.xml
+++ b/examples/xml/ipr-test.xml
@@ -10,7 +10,8 @@
      <title>The Interatomic Potentials Repository Project</title>
      <altTitle type="AlternativeTitle">The Interatomic Potentials Repository Project</altTitle>
      <shortName> IPR </shortName>
-     <version>2.0</version>
+     <version> 2.0 </version>
+     <identifier>ark:asdlf13871</identifier>
    </identity>
    <curation>
      <publisher> 
@@ -51,6 +52,9 @@
        related files are currently available for various metals,
        semiconductors, oxides, and carbon-containing systems. 	  
      </description>
+     <description>
+       You should try it.
+     </description>
      <subject> interatomic potentials </subject>
      <subject> molecular dynamics </subject>
      <subject> metals </subject>
@@ -68,7 +72,8 @@
      <primaryAudience> research </primaryAudience>
    </content>
    <role>
-      <type> Repository </type>
+     <type pid="http://purl.org/dc/dcmitype/Collection"> Collection: Repository </type>
+<!--     <type> Collection: Repository </type> -->
    </role>
    <applicability xsi:type="ms:MaterialsScience">
      <materialType> non-specific </materialType>

--- a/examples/xml/ipr.xml
+++ b/examples/xml/ipr.xml
@@ -15,9 +15,14 @@
      <publisher> 
        NIST/MSED Center for Theoretical and Computational Materials Science (CTCMS) 
      </publisher>
-     <creator> Chandler Becker </creator>
-     <contributor> Zachary Trautt </contributor>
-     <date role="Created" xsi:type="dcr:TypedDate"> 2008-04-01 </date>
+     <creator>
+       <name>Chandler Becker</name>
+       <affiliation> NIST </affiliation>
+     </creator>
+     <contributor role="DataCurator" xsi:type="dcr:DciteContributor">
+       <name>Zachary Trautt</name>
+     </contributor>
+     <date role="Created" xsi:type="dcr:DciteDate"> 2008-04-01 </date>
      <contact>
        <name>Zachary Trautt</name>
        <emailAddress> zachary.trautt@nist.gov </emailAddress>

--- a/examples/xml/schemaLocation.txt
+++ b/examples/xml/schemaLocation.txt
@@ -1,5 +1,6 @@
 http://www.openarchives.org/OAI/2.0/ ../../schemas/xml/extern/OAI-PMH-v2.0.xsd
 http://www.openarchives.org/OAI/2.0/oai_dc/ ../../schemas/xml/extern/oai_dc-v2.0.xsd
-urn:nist.gov/schema/res-md/1.0wd ../../schemas/xml/res-md.xsd
-urn:nist.gov/schema/mat-sci_res-md/1.0wd ../../schemas/xml/mat-sci_res-md.xsd
+http://schema.nist.gov/xml/res-md/1.0wd ../../schemas/xml/res-md.xsd
+http://schema.nist.gov/xml/resmd-datacite/1.0wd ../../schemas/xml/resmd-datacite.xsd
+http://schema.nist.gov/xml/mat-sci_res-md/1.0wd ../../schemas/xml/mat-sci_res-md.xsd
 

--- a/schemas/xml/mat-sci_res-md.xsd
+++ b/schemas/xml/mat-sci_res-md.xsd
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema targetNamespace="urn:nist.gov/schema/mat-sci_res-md/1.0wd" 
+<xs:schema targetNamespace="http://schema.nist.gov/xml/mat-sci_res-md/1.0wd" 
            xmlns="http://www.w3.org/2001/XMLSchema" 
            xmlns:xs="http://www.w3.org/2001/XMLSchema" 
-           xmlns:rsm="urn:nist.gov/schema/res-md/1.0wd" 
-           xmlns:ms="urn:nist.gov/schema/mat-sci_res-md/1.0wd" 
-           xmlns:am="urn:nist.gov/schema/mgi.schema.annot" 
+           xmlns:rsm="http://schema.nist.gov/xml/res-md/1.0wd" 
+           xmlns:ms="http://schema.nist.gov/xml/mat-sci_res-md/1.0wd" 
+           xmlns:am="http://schema.nist.gov/xml/mgi.schema.annot" 
            elementFormDefault="unqualified" 
            attributeFormDefault="unqualified" version="0.1">
 
@@ -21,7 +21,7 @@
       </xs:documentation>
    </xs:annotation>
 
-   <xs:import namespace="urn:nist.gov/schema/res-md/1.0wd"/>
+   <xs:import namespace="http://schema.nist.gov/xml/res-md/1.0wd"/>
 
    <xs:complexType name="MaterialsScience">
      <xs:annotation>

--- a/schemas/xml/res-md.xsd
+++ b/schemas/xml/res-md.xsd
@@ -99,8 +99,17 @@
              </xs:documentation>
            </xs:annotation>
          </xs:element>
-<!--
-  -->
+
+         <xs:element name="related" type="rsm:Related"
+                     minOccurs="0" maxOccurs="unbounded">
+           <xs:annotation>
+             <xs:documentation>
+               A reference to a related resource and the nature of the
+               relationship.
+             </xs:documentation>
+           </xs:annotation>
+         </xs:element>
+
       </xs:sequence>
 
       <xs:attribute name="localid">
@@ -410,7 +419,7 @@
                <am:dcterm>Contributor</am:dcterm>
              </xs:appinfo>
              <xs:documentation>
-               Entity responsible for contributions to the content of
+               Entity responsible for contributions to the development of
                the resource
              </xs:documentation>
           </xs:annotation>
@@ -983,6 +992,53 @@
 
      <xs:sequence>
        
+     </xs:sequence>
+   </xs:complexType>
+
+   <xs:complexType name="Related">
+     <xs:annotation>
+       <xs:documentation>
+         metadata describing describing a relationship between resources.
+       </xs:documentation>
+       <xs:documentation>
+         The subject of the relationship is the resource described by this
+         record.
+       </xs:documentation>
+     </xs:annotation>
+
+     <xs:sequence>
+       <xs:element name="relationship" type="rsm:NamePID">
+         <xs:annotation>
+           <xs:documentation>
+             The kind of relationship given by a relationship name
+             and, optionally, a URI.
+           </xs:documentation>
+           <xs:documentation>
+             It is recommended that these relationships be drawn from existing
+             ontologies with corresponding URI identifiers.  
+           </xs:documentation>
+           <xs:documentation>
+             It is recommended that the value given in the element content
+             be a displayable, human-friendly name for the relationship.
+             Subtypes (e.g. DciteRelation) can be used to provide a
+             controlled name where a URI is not defined.  
+           </xs:documentation>
+         </xs:annotation>
+       </xs:element>
+
+       <xs:element name="resource" type="rsm:NamePID"
+                   maxOccurs="unbounded">
+         <xs:annotation>
+           <xs:documentation>
+             The other resource that this resource is related to.
+           </xs:documentation>
+           <xs:documentation>
+             Multiple occurances can be provided to list all other resources
+             that this resource has the given relationship with.  
+           </xs:documentation>
+         </xs:annotation>
+       </xs:element>
+
      </xs:sequence>
    </xs:complexType>
 

--- a/schemas/xml/res-md.xsd
+++ b/schemas/xml/res-md.xsd
@@ -639,8 +639,9 @@
                 of a resource.  
               </xs:documentation>
               <xs:documentation>
-                recognized values include "created", "released", "published", 
-                and "established". 
+                This date type allows roles that are not covered by the
+                DciteDate type (which is prefered).  This should be used for
+                lifecycle events that are specific in nature to this resource.  
               </xs:documentation>
             </xs:annotation>
          </xs:attribute>
@@ -746,10 +747,11 @@
      </xs:annotation>
 
      <xs:sequence>
-       <xs:element name="description" type="xs:token">
+       <xs:element name="description" type="xs:token" maxOccurs="unbounded">
           <xs:annotation>
              <xs:appinfo>
                <am:dcterm>Description</am:dcterm>
+               <am:datacite>description</am:datacite>
              </xs:appinfo>           
              <xs:documentation>
                An account of the nature of the resource
@@ -758,6 +760,11 @@
                The description may include but is not limited to an abstract, 
                table of contents, reference to a graphical representation of
                content or a free-text account of the content.
+             </xs:documentation>
+             <xs:documentation>
+               Each description element represents a separate paragraph; thus,
+               order is significant (i.e. the first occurance is the first
+               paragraph).  The first occurance should give an overall summary.
              </xs:documentation>
           </xs:annotation>
        </xs:element>

--- a/schemas/xml/res-md.xsd
+++ b/schemas/xml/res-md.xsd
@@ -1,26 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema targetNamespace="urn:nist.gov/schema/res-md/1.0wd" 
+<xs:schema targetNamespace="http://schema.nist.gov/xml/res-md/1.0wd" 
            xmlns="http://www.w3.org/2001/XMLSchema" 
            xmlns:xs="http://www.w3.org/2001/XMLSchema" 
-           xmlns:rsm="urn:nist.gov/schema/res-md/1.0wd" 
-           xmlns:am="urn:nist.gov/nmrr.schema.annot" 
+           xmlns:rsm="http://schema.nist.gov/xml/res-md/1.0wd" 
+           xmlns:am="http://schema.nist.gov/xml/nmrr.schema.annot" 
            elementFormDefault="unqualified" 
-           attributeFormDefault="unqualified" version="0.7">
+           attributeFormDefault="unqualified" version="0.8">
 
    <xs:annotation>
       <xs:documentation>
         A metadata schema for describing resources in a research data 
-        federation.  This schema can be extended to incorporate domain-
-        specific metadata.  
+        federation.  This schema can be extended to describe new types
+        of resources and incorporate domain-specific metadata.  
       </xs:documentation>
       <xs:documentation>
-        This schema is based on VOResource v1.0 
+        This schema draws on concepts and patterns used in VOResource v1.0 
         (http://www.ivoa.net/xml/VOResource/v1.0) by Plante et al. 2008,
         VOResource: an XML Encoding Schema for Resource Metadata, v. 1.03
         (http://www.ivoa.net/documents/latest/VOResource.html).
       </xs:documentation>
    </xs:annotation>
 
+   <xs:import namespace="http://www.w3.org/XML/1998/namespace"
+              schemaLocation="http://www.w3.org/2009/01/xml.xsd"/>
+   
    <xs:complexType name="Resource">
       <xs:annotation>
          <xs:documentation>
@@ -57,7 +60,29 @@
          <xs:element name="content" type="rsm:Content">
            <xs:annotation>
              <xs:documentation>
-               Information regarding the general content of the resource
+               General information describing what the resource is and,
+               as appropriate, what it contains.
+             </xs:documentation>
+           </xs:annotation>
+         </xs:element>
+
+         <xs:element name="role" type="rsm:Role"
+                     minOccurs="1" maxOccurs="unbounded">
+           <xs:annotation>
+             <xs:documentation>
+               A label that identifies the type of resource this is along
+               with, if appropriate, a description of how this resource
+               fulfills its role as a that type of resource.
+             </xs:documentation>
+             <xs:documentation>
+               If this resource qualifies as being like multiple types of
+               resources at a time (e.g. a registry and a repository), multiple
+               role elements can be provided.
+             </xs:documentation>
+             <xs:documentation>
+               Sub-classes of Role can define additional metadata for describing
+               how it fulfills its role.  The xsi:type attribute must be used
+               to include this additional metadata.  
              </xs:documentation>
            </xs:annotation>
          </xs:element>
@@ -74,16 +99,8 @@
              </xs:documentation>
            </xs:annotation>
          </xs:element>
-
-         <xs:element name="access" type="rsm:Access" minOccurs="0">
-           <xs:annotation>
-             <xs:documentation>
-               Information describing how to access the resource and its 
-               features and capabilities.  
-             </xs:documentation>
-           </xs:annotation>
-         </xs:element>
-
+<!--
+  -->
       </xs:sequence>
 
       <xs:attribute name="localid">
@@ -94,6 +111,11 @@
             </xs:documentation>
             <xs:documentation>
               This attribute is required on export.
+            </xs:documentation>
+            <xs:documentation>
+              Authors may use this identifier for a proxy ID for the underlying
+              resource if one does not exist; if so desired, this ID should be
+              replicated as an identifier under the identity section.
             </xs:documentation>
          </xs:annotation>
       </xs:attribute>
@@ -134,6 +156,39 @@
       </xs:attribute>
    </xs:complexType>
 
+   <xs:complexType name="AccessibleResource">
+     <xs:annotation>
+       <xs:documentation>
+         a kind of resource that can be accessed as part of a federated data
+         application.  
+       </xs:documentation>
+       <xs:documentation>
+         This typically refers to things like data and software that can be
+         downloaded, accessed via an API or portal, or engaged using special
+         software.  
+       </xs:documentation>
+     </xs:annotation>
+
+     <xs:complexContent>
+       <xs:extension base="rsm:Resource">
+         <xs:sequence>
+
+           <xs:element name="access" type="rsm:Access" minOccurs="0">
+             <xs:annotation>
+               <xs:documentation>
+                 Information describing how to access the resource and its 
+                 features and capabilities.  
+               </xs:documentation>
+             </xs:annotation>
+           </xs:element>
+
+         </xs:sequence>
+       </xs:extension>
+     </xs:complexContent>
+
+   </xs:complexType>
+
+   
    <xs:complexType name="Identity">
      <xs:annotation>
        <xs:documentation>
@@ -146,9 +201,24 @@
             <xs:annotation>
                <xs:appinfo>
                  <am:dcterm>Title</am:dcterm>
+                 <am:dataciteproperty>Title</am:dataciteproperty>
                </xs:appinfo>           
                <xs:documentation>
                   the full name given to the resource
+               </xs:documentation>
+            </xs:annotation>
+         </xs:element>
+
+         <xs:element name="altTitle" type="rsm:AltTitle"
+                     minOccurs="0" maxOccurs="unbounded">
+            <xs:annotation>
+               <xs:appinfo>
+                 <am:dcterm>Title</am:dcterm>
+                 <am:dataciteproperty>Title</am:dataciteproperty>
+                 <am:comment>inspired by datacite Title</am:comment>
+               </xs:appinfo>           
+               <xs:documentation>
+                  an additional name the resource is known by
                </xs:documentation>
             </xs:annotation>
          </xs:element>
@@ -212,6 +282,83 @@
      </xs:sequence>
    </xs:complexType>
 
+   <xs:complexType name="AltTitle">
+     <xs:annotation>
+       <xs:documentation>
+         a title string that can indicate its role as an alternative title.
+       </xs:documentation>
+       <xs:documentation>
+         use of the xml:lang attribute is recommended when applicable
+       </xs:documentation>
+     </xs:annotation>
+
+     <xs:simpleContent>
+       <xs:extension base="xs:token"> 
+
+         <xs:attribute name="type" type="rsm:TitleType" use="required">
+            <xs:annotation>
+              <xs:appinfo>
+                <am:comment>inspired by datacite titleType</am:comment>
+                <am:dataciteproperty>titleType</am:dataciteproperty>
+              </xs:appinfo>
+              <xs:documentation>
+                The role of this title.
+              </xs:documentation>
+              <xs:documentation>
+                This is intended to help consumers properly display the title.
+              </xs:documentation>
+            </xs:annotation>
+         </xs:attribute>
+
+         <xs:attribute ref="xml:lang">
+            <xs:annotation>
+              <xs:documentation>
+                The language this title is given in
+              </xs:documentation>
+            </xs:annotation>
+         </xs:attribute>
+
+       </xs:extension>       
+     </xs:simpleContent>
+   </xs:complexType>
+
+   <xs:simpleType name="TitleType">
+     <xs:annotation>
+       <xs:documentation>
+         Allowed values for the AltTitle's type attribute
+       </xs:documentation>
+     </xs:annotation>
+
+     <xs:restriction base="xs:string">
+       <xs:enumeration value="AlternativeTitle">
+         <xs:annotation>
+           <xs:documentation>
+             title value represents an alternate or often used title for the
+             resource, but which is not its official or preferred title.
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="Subtitle">
+         <xs:annotation>
+           <xs:documentation>
+             title value represents a secondary or subtitle for the resource
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="TranslatedTitle">
+         <xs:annotation>
+           <xs:documentation>
+             title value represents a title in an alternate language as given
+             by the xml:lang attribute.  
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+         
+     </xs:restriction>
+   </xs:simpleType>
+        
    <xs:complexType name="Curation">
      <xs:annotation>
        <xs:documentation>
@@ -232,7 +379,18 @@
           </xs:annotation>
        </xs:element>
 
-       <xs:element name="creator" type="rsm:NamePID" 
+       <xs:element name="publicationYear" type="rsm:Year" minOccurs="0">
+          <xs:annotation>
+             <xs:appinfo>
+               <am:datacite>publicationYear</am:datacite>
+             </xs:appinfo>
+             <xs:documentation>
+               The year that this resource was made available by the publisher.
+             </xs:documentation>
+          </xs:annotation>
+       </xs:element>
+
+       <xs:element name="creator" type="rsm:Person" 
                    minOccurs="0" maxOccurs="unbounded">
           <xs:annotation>
              <xs:appinfo>
@@ -245,7 +403,7 @@
           </xs:annotation>
        </xs:element>
 
-       <xs:element name="contributor" type="rsm:NamePID" 
+       <xs:element name="contributor" type="rsm:Person" 
                    minOccurs="0" maxOccurs="unbounded">
           <xs:annotation>
              <xs:appinfo>
@@ -258,7 +416,7 @@
           </xs:annotation>
        </xs:element>
 
-       <xs:element name="date" type="rsm:RelevantDate" 
+       <xs:element name="date" type="rsm:Date" 
                    minOccurs="0" maxOccurs="unbounded">
           <xs:annotation>
              <xs:appinfo>
@@ -272,6 +430,11 @@
                This will typically be associated with the creation or 
                availability (i.e., most recent release or version) of
                the resource.  Use the role attribute to clarify.  
+             </xs:documentation>
+             <xs:documentation>
+                Since the Date type is abstract, one must describe
+                the interface using a subclass of Date, denoting
+                it via xsi:type.
              </xs:documentation>
           </xs:annotation>
        </xs:element>
@@ -317,51 +480,67 @@
 
        </xs:extension>       
      </xs:simpleContent>
-   </xs:complexType>   
+   </xs:complexType>
 
-   <xs:complexType name="RelevantDate">
+   <xs:complexType name="PersonName">
+     <xs:annotation>
+       <xs:documentation>
+         A representation of a person's name or position
+       </xs:documentation>
+       <xs:documentation>
+         The content is intended to provide the name as it should be presented
+         in a display.  It can either be an actual name (e.g. "John P. Doe")
+         or a role (e.g. "Archive Help Desk"). 
+       </xs:documentation>
+       <xs:documentation>
+         The optional sur, given, and middle attributes can be provided to
+         help dissect the name when converting to other formats or renderings.
+       </xs:documentation>
+     </xs:annotation>
+
      <xs:simpleContent>
-       <xs:extension base="rsm:Date"> 
+       <xs:extension base="rsm:NamePID">
 
-         <xs:attribute name="role" type="xs:string">
+         <xs:attribute name="sur" type="xs:string">
             <xs:annotation>
               <xs:documentation>
-                A label indicating the role this date plays in the lifecycle
-                of a resource.  
+                The part of the person's name that should be considered the
+                surname or family name.
               </xs:documentation>
-              <xs:documentation>
-                recognized values include "created", "released", and 
-                "established". 
-              </xs:documentation>
-            </xs:annotation>
+            </xs:annotation>           
          </xs:attribute>
-
-       </xs:extension>       
+         
+         <xs:attribute name="given" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                The part of the person's name that should be considered the
+                given or first name.
+              </xs:documentation>
+            </xs:annotation>           
+         </xs:attribute>
+         
+         <xs:attribute name="middle" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                The part of the person's name that should be considered the
+                middle names or initials.  
+              </xs:documentation>
+            </xs:annotation>           
+         </xs:attribute>
+         
+       </xs:extension>
      </xs:simpleContent>
-   </xs:complexType>   
+   </xs:complexType>
 
-   <xs:simpleType name="Date">
+   <xs:complexType name="Person">
      <xs:annotation>
        <xs:documentation>
-         A relaxed format for expressing dates consistent with the Dublin
-         Core Date 
-         (http://dublincore.org/documents/usageguide/elements.shtml#Date)
-         and the W3C Note on data formats (http://www.w3.org/TR/NOTE-datetime).
+         A representation of a person
        </xs:documentation>
      </xs:annotation>
-     <xs:restriction base="xs:token">
-       <xs:pattern value="\d{4}(-\d{2}(-\d{2})?)?"/>
-     </xs:restriction>
-   </xs:simpleType>
 
-   <xs:complexType name="Contact">
-     <xs:annotation>
-       <xs:documentation>
-         Information that can be used for contacting someone
-       </xs:documentation>
-     </xs:annotation>
      <xs:sequence>
-       <xs:element name="name" type="rsm:NamePID">
+       <xs:element name="name" type="rsm:PersonName">
           <xs:annotation>
              <xs:documentation>
                  the name or title of the contact person.
@@ -373,7 +552,123 @@
           </xs:annotation>
        </xs:element>
 
-       <xs:element name="postalAddress" type="xs:token" minOccurs="0">
+       <xs:element name="affiliation" type="rsm:NamePID" minOccurs="0">
+          <xs:annotation>
+             <xs:documentation>
+               the name of the institute or organization that this
+               person was affiliated with when the person contributed
+               to this resource.
+             </xs:documentation>
+          </xs:annotation>
+       </xs:element>
+     </xs:sequence>
+
+   </xs:complexType>   
+
+   <xs:simpleType name="Year">
+     <xs:annotation>
+       <xs:documentation>
+         An A.D. year date with format YYYY.
+       </xs:documentation>
+     </xs:annotation>
+
+     <xs:restriction base="xs:token">
+        <xs:pattern value="[\d]{4}"/>
+     </xs:restriction>
+   </xs:simpleType>
+
+   <xs:simpleType name="NoTimeDate">
+     <xs:annotation>
+       <xs:documentation>
+         A restricted format for expressing dates compliant with the Datacite
+         date formatting recommendations.  The value is either a single year,
+         month, or day value (compliant with the W3C Note on data formats,
+         http://www.w3.org/TR/NOTE-datetime), or two such values delimited by
+         a slash, indicating a range of values.
+       </xs:documentation>
+       <xs:documentation>
+         Single values are restricted to the following forms:  YYYY, YYYY-MM,
+         or YYYY-MM-DD.  
+       </xs:documentation>
+     </xs:annotation>
+
+     <xs:restriction base="xs:token">
+       <xs:pattern value="\d{4}(-\d{2}(-\d{2}(/\d{4}(-\d{2}(-\d{2})?)?)?)?)?"/>
+     </xs:restriction>
+   </xs:simpleType>
+
+   <xs:complexType name="Date" abstract="true">
+     <xs:annotation>
+       <xs:documentation>
+         An abstract type for date elements that can accept qualifying
+         attributes (e.g. see LocalEvent)
+       </xs:documentation>
+       <xs:documentation>
+         Single values are restricted to the following forms:  YYYY, YYYY-MM,
+         or YYYY-MM-DD.  
+       </xs:documentation>
+     </xs:annotation>
+
+     <xs:simpleContent>
+       <xs:extension base="rsm:NoTimeDate">
+       </xs:extension>
+     </xs:simpleContent>
+   </xs:complexType>
+
+   <xs:complexType name="LocalEvent">
+     <xs:annotation>
+       <xs:documentation>
+         A date for an event in the lifecycle of a resource that is specific
+         to the publisher or contributor to the resource.  
+       </xs:documentation>
+       <xs:documentation>
+         This allows publishers to indicate customized event dates through an
+         arbitrary role attribute value.  One should prefer the use of 
+         DataciteDate (which controls the value of the role attribute) over
+         LocalEvent if one of the former's controlled values apply.  
+       </xs:documentation>
+     </xs:annotation>
+
+     <xs:simpleContent>
+       <xs:extension base="rsm:Date"> 
+
+         <xs:attribute name="role" type="xs:string">
+            <xs:annotation>
+              <xs:documentation>
+                A label indicating the role this date plays in the lifecycle
+                of a resource.  
+              </xs:documentation>
+              <xs:documentation>
+                recognized values include "created", "released", "published", 
+                and "established". 
+              </xs:documentation>
+            </xs:annotation>
+         </xs:attribute>
+
+       </xs:extension>       
+     </xs:simpleContent>
+   </xs:complexType>   
+
+   <xs:complexType name="Contact">
+     <xs:annotation>
+       <xs:documentation>
+         Information that can be used for contacting someone
+       </xs:documentation>
+     </xs:annotation>
+     <xs:sequence>
+       <xs:element name="name" type="rsm:PersonName">
+          <xs:annotation>
+             <xs:documentation>
+                 the name or title of the contact person.
+             </xs:documentation>
+             <xs:documentation>
+                 This can be a person's name, e.g. "John P. Jones" or
+                 a group, "Archive Support Team".
+             </xs:documentation>
+          </xs:annotation>
+       </xs:element>
+
+       <xs:element name="postalAddress" type="rsm:PostalAddress" minOccurs="0">
           <xs:annotation>
              <xs:documentation>the contact mailing address</xs:documentation>
              <xs:documentation>
@@ -409,6 +704,27 @@
      </xs:sequence>
    </xs:complexType>
 
+   <xs:complexType name="PostalAddress">
+     <xs:annotation>
+       <xs:documentation>
+         A postal address structured to enable formatting according to
+         local conventions
+       </xs:documentation>
+     </xs:annotation>
+
+     <xs:sequence>
+       <xs:element name="addressLine" type="xs:token"
+                   minOccurs="1" maxOccurs="unbounded">
+          <xs:annotation>
+             <xs:documentation>
+               One line of the address as it should appear on an envelope.
+             </xs:documentation>
+          </xs:annotation>
+       </xs:element>
+     </xs:sequence>
+
+   </xs:complexType>
+
    <xs:simpleType name="TimeZone">
      <xs:annotation>
        <xs:documentation>
@@ -430,18 +746,6 @@
      </xs:annotation>
 
      <xs:sequence>
-       <xs:element name="type" type="rsm:NamePID" 
-                   minOccurs="0" maxOccurs="unbounded">
-          <xs:annotation>
-             <xs:appinfo>
-               <am:dcterm>Type</am:dcterm>
-             </xs:appinfo>
-             <xs:documentation>
-               Nature or genre of the resource
-             </xs:documentation>
-          </xs:annotation>
-       </xs:element>
-
        <xs:element name="description" type="xs:token">
           <xs:annotation>
              <xs:appinfo>
@@ -458,7 +762,7 @@
           </xs:annotation>
        </xs:element>
 
-       <xs:element name="subject" type="xs:token" maxOccurs="unbounded">
+       <xs:element name="subject" type="rsm:Subject" maxOccurs="unbounded">
           <xs:annotation>
              <xs:appinfo>
                <am:dcterm>Subject</am:dcterm>
@@ -487,7 +791,7 @@
                 discusses this resource.
              </xs:documentation>
              <xs:documentation>
-                The value is a human-consumable version of the reference, such
+                The value is a human-consumable citation of the reference, such
                 as a formatted bibliographic representation (e.g. used in 
                 an article bibliography).  The pid attribute gives a persistant 
                 or otherwise unambiguous identifier for the article; a DOI
@@ -514,6 +818,53 @@
 
      </xs:sequence>
    </xs:complexType>
+
+   <xs:complexType name="Subject">
+     <xs:annotation>
+       <xs:documentation>
+         a type for expressing a subject keyword that may be drawn from
+         a standard set of keywords
+       </xs:documentation>
+     </xs:annotation>
+
+     <xs:simpleContent>
+       <xs:extension base="xs:token">
+         <xs:attribute name="scheme" use="optional" type="xs:string">
+           <xs:annotation>
+             <xs:documentation>
+               a label or classification code indicating the vocabulary that
+               this subject keyword was drawn from
+             </xs:documentation>
+           </xs:annotation>
+         </xs:attribute>
+
+         <xs:attribute name="schemeURI" use="optional" type="xs:anyURI">
+           <xs:annotation>
+             <xs:documentation>
+               The URI identifying or describing the vocabulary that
+               the subject keyword was drawn from
+             </xs:documentation>
+           </xs:annotation>
+         </xs:attribute>
+
+         <xs:attribute name="pid" type="xs:anyURI">
+           <xs:annotation>
+             <xs:documentation>
+               The machine-recognizable URI identifying the specific subject 
+               keyword.
+             </xs:documentation>
+             <xs:documentation>
+               Use this attribute if the keyword corresponds to a subject from
+               an RDF vocabulary.
+             </xs:documentation>
+           </xs:annotation>
+         </xs:attribute>
+
+       </xs:extension>
+     </xs:simpleContent>
+
+   </xs:complexType>
+   
 
    <xs:simpleType name="Audience">
      <xs:annotation>
@@ -547,6 +898,73 @@
        </xs:enumeration>
      </xs:restriction>
    </xs:simpleType>
+
+   <xs:complexType name="Role">
+     <xs:annotation>
+       <xs:documentation>
+         metadata describing the resource's role as a resource of a particular
+         type.  
+       </xs:documentation>
+       <xs:documentation>
+         This base XML type only provides a type label (and possibly an
+         identifier); however, this XML Role type can be extended to support
+         additional metadata applicable only to particular types.  
+       </xs:documentation>
+     </xs:annotation>
+
+     <xs:sequence>
+        <xs:element name="type" type="rsm:RoleType">
+          <xs:annotation>
+             <xs:documentation>
+               a label that indicates the kind of resource it is.
+             </xs:documentation>
+             <xs:documentation>
+               This corresponds to the DC element, type.  Values may be drawn,
+               for example, from the DCMI Type Vocabulary.
+             </xs:documentation>
+             <xs:documentation>
+               This label may use any format or convention for these labels.  An
+               xsi:type on this element or on the parent element may be used to
+               imply/enforce a particular format.  
+             </xs:documentation>
+             <xs:documentation>
+               In the absense of xsi:type usage that restricts the labels that
+               can be used, the following format is recommended:
+               the value can be a colon-separated list of
+               of labels in order of most general to most specific
+               (i.e. each the last label represents a more specific term for the 
+               ones that precede it).  Applications may choose to display only 
+               the last label or the entire string, depending on the context.  
+             </xs:documentation>
+          </xs:annotation>
+        </xs:element>
+
+     </xs:sequence>
+   </xs:complexType>   
+
+   <xs:complexType name="RoleType">
+     <xs:simpleContent>
+       <xs:extension base="xs:token"> 
+
+         <xs:attribute name="pid" type="xs:anyURI">
+            <xs:annotation>
+              <xs:documentation>
+                An unambigous identifier that identifies a resource type having
+                a defined meaning, indicating that this resource is some variety
+                of the resource type given by that meaning.  
+              </xs:documentation>
+              <xs:documentation>
+                An example would a DCMI Type Vocabulary URI like
+                http://purl.org/dc/dcmitype/PhysicalObject.  The label may 
+                indicate that the type is some more precise variety (e.g. a
+                soil sample).
+              </xs:documentation>
+            </xs:annotation>
+         </xs:attribute>
+
+       </xs:extension>       
+     </xs:simpleContent>
+   </xs:complexType>
 
    <xs:complexType name="Applicability">
      <xs:annotation>

--- a/schemas/xml/resmd-datacite.xsd
+++ b/schemas/xml/resmd-datacite.xsd
@@ -1,0 +1,496 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://schema.nist.gov/xml/resmd-datacite/1.0wd" 
+           xmlns="http://www.w3.org/2001/XMLSchema" 
+           xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+           xmlns:rsm="http://schema.nist.gov/xml/res-md/1.0wd" 
+           xmlns:dcr="http://schema.nist.gov/xml/resmd-datacite/1.0wd" 
+           xmlns:am="http://schema.nist.gov/xml/nmrr.schema.annot" 
+           elementFormDefault="unqualified" 
+           attributeFormDefault="unqualified" version="0.1">
+
+   <xs:annotation>
+      <xs:documentation>
+        A metadata extension schema to res-md (a metadata schema for
+        describing resources in research data federation) that
+        provides Datacite-compatible types.
+      </xs:documentation>
+      <xs:documentation>
+        The defintions here are directly derived from the Datacite
+        Metadata Schema version 3.1 (https://schema.datacite.org/meta/kernel-3/).
+      </xs:documentation>
+   </xs:annotation>
+
+   <xs:import namespace="http://schema.nist.gov/xml/res-md/1.0wd"/>
+
+   <xs:complexType name="DciteDate">
+     <xs:annotation>
+       <xs:documentation>
+         A date for an event in the lifecycle of a resource corresponding to
+         one of the Datacite (v3.1) date types.
+       </xs:documentation>
+       <xs:documentation>
+         This type can be used an xsi:type-specified date element.  
+       </xs:documentation>
+     </xs:annotation>
+
+     <xs:simpleContent>
+       <xs:extension base="rsm:Date"> 
+
+         <xs:attribute name="role" type="dcr:DateType">
+            <xs:annotation>
+              <xs:documentation>
+                A label indicating the role this date plays in the lifecycle
+                of a resource.  
+              </xs:documentation>
+              <xs:documentation>
+                This is restricted to be one of the Datacite defined values.
+              </xs:documentation>
+            </xs:annotation>
+         </xs:attribute>
+
+       </xs:extension>       
+     </xs:simpleContent>
+   </xs:complexType>
+
+   <xs:simpleType name="DateType">
+     <xs:annotation>
+       <xs:appinfo>
+         <am:dataciteproperty>dateType</am:dataciteproperty>
+       </xs:appinfo>
+       <xs:documentation>
+         A type of date (i.e. a role) important to the publishing of
+         a resource which corresponds to those defined by the Datacite
+         Metadata schema (v3.1)
+       </xs:documentation>
+     </xs:annotation>
+
+     <xs:restriction base="xs:string">
+
+       <xs:enumeration value="Accepted">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>Accepted</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating the date that the publisher accepted the resource
+             into their system
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="Available">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>Available</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating the date (or date range) that the resource is made
+             publicly available
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="Collected">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>Collected</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating the date (or date range) in which the resource content
+             was collected
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="Copyrighted">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>Copyrighted</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating the specific, documented date at which the resource
+             receives a copyrighted status, if applicable.  
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+         
+       <xs:enumeration value="Created">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>Created</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating the date (or date range) that the resource itself was
+             pub together.  A single date indicates when the creation was
+             completed.  
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="Issued">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>Issued</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating the date (or date range) that the resource is published
+             or distributed
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="Submitted">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>Submitted</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating the date that the creator submits the resource to the
+             publisher.  
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="Updated">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>Updated</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating the date (or date range) of the last update to the 
+             resource.  
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="Valid">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>Valid</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating the date (or date range) during which the resource 
+             is accurate.  
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+     </xs:restriction>
+   </xs:simpleType>
+
+   <xs:complexType name="DciteContributor">
+     <xs:annotation>
+       <xs:documentation>
+         a contributor that plays one of the roles defined by the
+         datacite metadata schema.  
+       </xs:documentation>
+     </xs:annotation>
+
+     <xs:complexContent>
+       <xs:extension base="rsm:Person">
+
+          <xs:attribute name="role" type="dcr:ContributorType">
+            <xs:annotation>
+              <xs:documentation>
+                a label indicating the contribution that this person
+                or organization made to the resource.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+
+       </xs:extension>
+     </xs:complexContent>
+
+   </xs:complexType>
+
+   <xs:simpleType name="ContributorType">
+     <xs:annotation>
+       <xs:appinfo>
+         <am:dataciteproperty>ContributorType</am:dataciteproperty>
+       </xs:appinfo>
+       <xs:documentation>
+         Controlled labels that indicate the type of contribution
+         made which correspond to those defined by the Datacite
+         Metadata schema (v3.1)
+       </xs:documentation>
+       <xs:documentation>
+         Note that ContactPerson is not defined; the &lt;contact&gt; element
+         should be used instead.  
+       </xs:documentation>
+     </xs:annotation>
+
+     <xs:restriction base="xs:string">
+
+       <xs:enumeration value="DataCollector">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>DataCollector</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating a person or institution responsible for
+             finding, gathering/collecting data under the guidelines
+             of the author(s) or principal investigator.  
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="DataCurator">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>DataCurator</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating a person or institution tasked with reviewing,
+             enhancing, cleaning, or standardizing metadata and the
+             associated data submitted for storage, use, and
+             mainteneance witin a data cetner or repository
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="DataManager">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>DataManager</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating a person or organization responsible for maintaining
+             the finished resource 
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="Distributor">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>Distributor</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating the institution tasked with responsibility to
+             generate/disseminate copies of the resource in either electronic
+             or print form.  
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="Editor">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>Editor</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating a person who oversees the details related to the
+             publication format of the resource
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="Funder">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>Funder</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating an institution that provided financial support for the
+             development of the resource 
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="HostingInstitution">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>HostingInstitution</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating the organization allowing the resource to be available
+             on the internet through the provision of its
+             hardware/software/operating support
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="Producer">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>Producer</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating a person or organization responsible for the artistry
+             and form of a media product
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="ProjectLeader">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>ProjectLeader</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating a person officially designated as head of a project
+             team instrumental in the work necessary to the development of
+             the resource 
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="ProjectManager">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>ProjectManager</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating a person officially designated as manager of a project
+             which was instrumental in the work necessary to the development of
+             the resource
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="ProjectMember">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>ProjectMember</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating a person on the membership list of a designated project
+             or project team which was instrumental in the work necessary to
+             the development of the resource
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="RegistrationAgency">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>RegistrationAgency</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating an institution/organization officially appointed by
+             a registration authority to handle specific tasks within a
+             defined area of responsibility
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="RegistrationAuthority">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>RegistrationAuthority</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating a standards-setting body from which registration
+             agencies obtain official recognition and guidance
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="RelatedPerson">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>RelatedPerson</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating a person without a specifically defined role in the
+             development of the resource, but who is someone a creator wishes
+             to recognize.
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="Researcher">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>Researcher</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating a person involved in analyzing data or the results of
+             an experiment or formal study.
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="ResearchGroup">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>ResearchGroup</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating a group of individuals with a lab, department, or
+             division with a particular, defined focus of activity
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="RightsHolder">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>RightsHolder</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating a person or institution owning or managing property
+             rights, including intellectual property rights, over the resource
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="Sponsor">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>Sponsor</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating a person or organization that issued a contract or
+             under the auspices of which a work has been written, printed,
+             published, developed, etc. 
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="Supervisor">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>Supervisor</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating a designated administrator over one or more groups/teams
+             working to produce the resource or over one or more streps of the 
+             development process
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="WorkPackageLeader">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>WorkPackageLeader</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating a person responsible for ensuring the comprehensive
+             contents, versioning, and availability of a work package (i.e.
+             a recognized data product, not all of which may be included in the
+             resource) during the development of the resource.
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="Other">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>Other</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             indicating a person or organization making a significant
+             contribution to the development and/or maintenance of the
+             resource, but whose contribution does not fit the definitions
+             of the other defined contributor types.  
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+     </xs:restriction>
+   </xs:simpleType>
+
+</xs:schema>
+   

--- a/schemas/xml/resmd-datacite.xsd
+++ b/schemas/xml/resmd-datacite.xsd
@@ -189,7 +189,7 @@
      <xs:complexContent>
        <xs:extension base="rsm:Person">
 
-          <xs:attribute name="role" type="dcr:ContributorType">
+          <xs:attribute name="role" type="dcr:ContributorType" use="required">
             <xs:annotation>
               <xs:documentation>
                 a label indicating the contribution that this person

--- a/schemas/xml/resmd-datacite.xsd
+++ b/schemas/xml/resmd-datacite.xsd
@@ -492,5 +492,350 @@
      </xs:restriction>
    </xs:simpleType>
 
+   <xs:complexType name="DciteRelation">
+     <xs:annotation>
+       <xs:documentation>
+         a relationship type that corresponds directly to one of the types 
+         defined by the datacite metadata schema.  
+       </xs:documentation>
+     </xs:annotation>
+
+     <xs:complexContent>
+       <xs:extension base="rsm:NamePID">
+          <xs:attribute name="label" type="dcr:RelationType" use="required">
+            <xs:annotation>
+              <xs:documentation>
+                a label indicating the Datacite defined relationship type.
+              </xs:documentation>
+            </xs:annotation>
+          </xs:attribute>
+       </xs:extension>
+     </xs:complexContent>
+
+   </xs:complexType>
+
+   <xs:simpleType name="RelationType">
+     <xs:annotation>
+       <xs:appinfo>
+         <am:dataciteproperty>RelationType</am:dataciteproperty>
+       </xs:appinfo>
+       <xs:documentation>
+         Controlled labels that indicate a type of relationship
+         between the resource the record describes (the subject resource)
+         and another resource (the target resource).  These types
+         correspond to those defined by the Datacite Metadata schema (v3.1).
+       </xs:documentation>
+     </xs:annotation>
+
+     <xs:restriction base="xs:string">
+
+       <xs:enumeration value="IsCitedBy">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>IsCitedBy</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             a relationship indicating that the targe resource includes
+             the subject resource in a citation
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="Cites">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>Cites</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             a relationship indicating that the subject resource includes
+             the target resource in a citation
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="IsSupplementTo">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>IsSupplementTo</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             a relationship indicating that the subject resource is a supplement
+             to the target resource
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="IsSupplementedBy">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>IsSupplementedBy</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             a relationship indicating that the target resource is a supplement
+             to the subject resource
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="IsContinuedBy">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>IsContinuedBy</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             a relationship indicating that the subject resource is continued
+             by the target resource
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="Continues">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>Continues</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             a relationship indicating that the subject resource is a 
+             continuation for the target resource in a citation
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="HasMetadata">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>HasMetadata</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             a relationship indicating that the target resource provides
+             additional metadata about the subject resource
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="IsMetadataFor">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>IsMetadataFor</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             a relationship indicating that the subject resource provides
+             additional metadata about the target resource
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="IsNewVersionOf">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>IsNewVersionOf</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             a relationship indicating that the subject resource is a new 
+             edition of the target resource, where the new edition is a
+             modification or update
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="IsPreviousVersionOf">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>IsPreviousVersionOf</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             a relationship indicating that the subject resource is a previous
+             edition of the target resource
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="IsPartOf">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>IsPartOf</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             a relationship indicating that the subject resource is a portion
+             of the target resource
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="HasPart">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>HasPart</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             a relationship indicating that the subject resource includes 
+             the target resource
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="IsReferencedBy">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>IsReferencedBy</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             a relationship indicating that the subject resource is used as a
+             source of information or data by the target resource
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="References">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>References</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             a relationship indicating that the target resource is used as a
+             source of information or data by the subject resource
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="IsDocumentedBy">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>IsDocumentedBy</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             a relationship indicating that the target resource is documentation
+             about or explaining the subject resource
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="Documents">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>Documents</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             a relationship indicating that the subject resource is documentation
+             about or explaining the target resource
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="IsCompiledBy">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>IsCompiledBy</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             a relationship indicating that the target resource is used to 
+             compile or create the subject resource
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="Compiles">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>Compiles</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             a relationship indicating that the target resource is the result 
+             of a compile or creation event using the subject resource
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="IsVariantFormOf">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>IsVariantFormOf</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             a relationship indicating that the subject resource is a variant or 
+             different form of the the target resource, e.g. calculated or
+             calibrated form or uses different packaging
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="IsOriginalFormOf">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>IsOriginalFormOf</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             a relationship indicating that the subject resource is the original
+             form of the the target resource (e.g. before some transformation).
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="IsIdenticalTo">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>IsIdenticalTo</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             a relationship indicating that the subject and target resources 
+             are separate instances of the identical resource
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="IsReviewedBy">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>IsReviewedBy</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             a relationship indicating that the subject resource is reviewed by
+             the target resource 
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="Reviews">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>Reviews</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             a relationship indicating that the subject resource is a review of
+             the target resource 
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="IsDerivedFrom">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>IsDerivedFrom</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             a relationship indicating that the target resource is a source 
+             upon which the subject resource is based
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+       <xs:enumeration value="IsSourceOf">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dataciteproperty>IsSourceOf</am:dataciteproperty>
+           </xs:appinfo>
+           <xs:documentation>
+             a relationship indicating that the subject resource is a source 
+             upon which the target resource is based
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+
+     </xs:restriction>
+   </xs:simpleType>
+
+
+   
+
 </xs:schema>
    

--- a/tools/xslt/resmd2datacite.xsl
+++ b/tools/xslt/resmd2datacite.xsl
@@ -1,0 +1,578 @@
+<?xml version="1.0"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:dc="http://datacite.org/schema/kernel-3"
+                xmlns:rsm="http://schema.nist.gov/xml/res-md/1.0wd" 
+                xmlns:rdc="http://schema.nist.gov/xml/resmd-datacite/1.0wd"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xmlns="http://datacite.org/schema/kernel-3"
+                exclude-result-prefixes="dc rsm rdc xsi" 
+                version="1.0">
+                
+<!-- Stylesheet for converting mgi-resmd records to datacite records -->
+
+   <xsl:output method="xml" encoding="UTF-8" indent="no" />
+   <xsl:variable name="autoIndent" select="'  '"/>
+   <xsl:preserve-space elements="*"/>
+
+   <!--
+     -  If true, insert carriage returns and indentation to produce a neatly 
+     -  formatted output.  If false, any spacing between tags in the source
+     -  document will be preserved.  
+     -->
+   <xsl:param name="prettyPrint" select="true()"/>
+
+   <!--
+     -  the per-level indentation.  Set this to a sequence of spaces when
+     -  pretty printing is turned on.
+     -->
+   <xsl:param name="indent">
+      <xsl:for-each select="/*/*[2]">
+         <xsl:call-template name="getindent"/>
+      </xsl:for-each>
+   </xsl:param>
+
+   <xsl:param name="dataciteNS">http://datacite.org/schema/kernel-3</xsl:param>
+
+   <xsl:variable name="cr"><xsl:text>
+</xsl:text></xsl:variable>
+
+   <!-- ==========================================================
+     -  General templates
+     -  ========================================================== -->
+
+   <xsl:template match="/">
+      <xsl:apply-templates select="*">
+         <xsl:with-param name="sp">
+            <xsl:if test="$prettyPrint">
+              <xsl:value-of select="$cr"/>
+            </xsl:if>
+         </xsl:with-param>
+         <xsl:with-param name="step">
+            <xsl:if test="$prettyPrint">
+              <xsl:value-of select="$indent"/>
+            </xsl:if>
+         </xsl:with-param>
+      </xsl:apply-templates>
+   </xsl:template>
+
+
+   <xsl:template match="/*[identity]">
+     <xsl:param name="sp"/>
+     <xsl:param name="step"/>
+
+     <xsl:element name="resource" namespace="{$dataciteNS}">
+     
+       <xsl:apply-templates select="identity" mode="identifier">
+         <xsl:with-param name="sp" select="concat($sp,$step)"/>
+         <xsl:with-param name="step" select="$step"/>
+       </xsl:apply-templates>
+
+       <xsl:apply-templates select="curation" mode="creators">       
+         <xsl:with-param name="sp" select="concat($sp,$step)"/>
+         <xsl:with-param name="step" select="$step"/>
+       </xsl:apply-templates>
+
+       <xsl:apply-templates select="identity" mode="titles">       
+         <xsl:with-param name="sp" select="concat($sp,$step)"/>
+         <xsl:with-param name="step" select="$step"/>
+       </xsl:apply-templates>
+
+       <xsl:apply-templates select="curation/publisher">       
+         <xsl:with-param name="sp" select="concat($sp,$step)"/>
+         <xsl:with-param name="step" select="$step"/>
+       </xsl:apply-templates>
+
+       <xsl:apply-templates select="curation/publicationYear">       
+         <xsl:with-param name="sp" select="concat($sp,$step)"/>
+         <xsl:with-param name="step" select="$step"/>
+       </xsl:apply-templates>
+
+       <xsl:apply-templates select="content" mode="subjects">       
+         <xsl:with-param name="sp" select="concat($sp,$step)"/>
+         <xsl:with-param name="step" select="$step"/>
+       </xsl:apply-templates>
+
+       <xsl:value-of select="$sp"/>
+     </xsl:element>
+   </xsl:template>
+
+   <xsl:template match="identity" mode="identifier">
+     <xsl:param name="sp"/>
+     <xsl:param name="step"/>
+
+     <xsl:value-of select="$sp"/>
+     <xsl:choose>
+       <xsl:when test="identifier[@type='DOI']">
+         <identifier doiType="DOI">
+           <xsl:value-of select="identifier[@type='DOI']"/>
+         </identifier>
+       </xsl:when>
+       <xsl:otherwise>
+         <identifier doiType="URL">
+           <xsl:value-of select="../@localid"/>
+         </identifier>
+       </xsl:otherwise>
+     </xsl:choose>
+
+   </xsl:template>
+
+   <xsl:template match="curation" mode="creators">
+     <xsl:param name="sp"/>
+     <xsl:param name="step"/>
+
+     <xsl:value-of select="$sp"/>
+     <creators>
+        <xsl:if test="creator">
+          <xsl:apply-templates select="creator" mode="creators">
+            <xsl:with-param name="sp" select="concat($sp,$step)"/>
+            <xsl:with-param name="step" select="$step"/>
+          </xsl:apply-templates>       
+          <xsl:value-of select="$sp"/>
+        </xsl:if>
+     </creators>
+   </xsl:template>
+
+   <xsl:template match="creator" mode="creators">
+     <xsl:param name="sp"/>
+     <xsl:param name="step"/>
+
+     <xsl:variable name="subsp" select="concat($sp,$step)"/>
+
+     <xsl:value-of select="$sp"/>
+     <creator>
+       <xsl:value-of select="$subsp"/>
+       <creatorName>
+          <xsl:apply-templates select="name" mode="flipName"/>
+       </creatorName>
+       <xsl:if test="@pid">
+          <xsl:variable name="scheme">
+             <xsl:apply-templates select="@pid" mode="getidscheme"/>
+          </xsl:variable>
+          
+          <xsl:value-of select="$subsp"/>
+          <nameIdentifier nameIdentifierScheme="$scheme">
+             <xsl:value-of select="@pid"/>
+          </nameIdentifier>
+       </xsl:if>
+       <xsl:value-of select="$sp"/>
+     </creator>
+   </xsl:template>
+
+   <xsl:template match="identity" mode="titles">
+     <xsl:param name="sp"/>
+     <xsl:param name="step"/>
+
+     <xsl:variable name="subsp" select="concat($sp,$step)"/>
+
+     <xsl:value-of select="$sp"/>
+     <titles>
+       <xsl:apply-templates select="title" mode="titles">
+         <xsl:with-param name="sp" select="concat($sp,$step)"/>
+         <xsl:with-param name="step" select="$step"/>
+       </xsl:apply-templates>
+
+       <xsl:apply-templates select="altTitle" mode="titles">
+         <xsl:with-param name="sp" select="concat($sp,$step)"/>
+         <xsl:with-param name="step" select="$step"/>
+       </xsl:apply-templates>
+
+       <xsl:value-of select="$sp"/>
+     </titles>      
+   </xsl:template>
+
+   <xsl:template match="title" mode="titles">
+     <xsl:param name="sp"/>
+     <xsl:param name="step"/>
+
+     <xsl:value-of select="$sp"/>
+     <title>
+        <xsl:value-of select="normalize-space(.)"/>
+     </title>
+   </xsl:template>
+
+   <xsl:template match="altTitle" mode="titles">
+     <xsl:param name="sp"/>
+     <xsl:param name="step"/>
+
+     <xsl:value-of select="$sp"/>
+     <xsl:element name="title">
+        <xsl:attribute name="titleType">
+           <xsl:value-of select="@type"/>
+        </xsl:attribute>
+        <xsl:if test="@xml:lang">
+           <xsl:attribute name="xml:lang">
+              <xsl:value-of select="@xml:lang"/>
+           </xsl:attribute>
+        </xsl:if>
+
+        <xsl:value-of select="normalize-space(.)"/>
+
+     </xsl:element>
+   </xsl:template>
+
+   <xsl:template match="publisher">
+     <xsl:param name="sp"/>
+     <xsl:param name="step"/>
+
+     <xsl:value-of select="$sp"/>
+     <publisher>
+        <xsl:value-of select="normalize-space(.)"/>
+     </publisher>
+   </xsl:template>
+
+   <xsl:template match="publicationYear">
+     <xsl:param name="sp"/>
+     <xsl:param name="step"/>
+
+     <xsl:value-of select="$sp"/>
+     <publicationYear>
+        <xsl:value-of select="."/>
+     </publicationYear>
+   </xsl:template>
+
+   <xsl:template match="content" mode="subjects">
+     <xsl:param name="sp"/>
+     <xsl:param name="step"/>
+
+     <xsl:value-of select="$sp"/>
+     <subjects>
+        <xsl:if test="subject">
+          <xsl:apply-templates select="subject" mode="subjects">
+            <xsl:with-param name="sp" select="concat($sp,$step)"/>
+            <xsl:with-param name="step" select="$step"/>
+          </xsl:apply-templates>       
+          <xsl:value-of select="$sp"/>
+        </xsl:if>
+     </subjects>
+   </xsl:template>
+
+   <xsl:template match="subject" mode="subjects">
+     <xsl:param name="sp"/>
+     <xsl:param name="step"/>
+
+     <xsl:variable name="subsp" select="concat($sp,$step)"/>
+
+     <xsl:value-of select="$sp"/>
+     <xsl:element name="subject">
+        <xsl:if test="@scheme">
+           <xsl:attribute name="subjectScheme">
+              <xsl:value-of select="@scheme"/>
+           </xsl:attribute>
+        </xsl:if>
+        <xsl:if test="@schemeURI">
+           <xsl:attribute name="schemeURI">
+              <xsl:value-of select="@schemeURI"/>
+           </xsl:attribute>
+        </xsl:if>
+        <xsl:if test="@xml:lang">
+           <xsl:attribute name="xml:lang">
+              <xsl:value-of select="@xml:lang"/>
+           </xsl:attribute>
+        </xsl:if>
+
+        <xsl:value-of select="normalize-space(.)"/>
+
+     </xsl:element>
+   </xsl:template>
+
+
+   <!-- ==========================================================
+     -  Utility templates
+     -  ========================================================== -->
+
+   <!--
+     -  determine the indentation preceding the context element
+     -->
+   <xsl:template name="getindent">
+      <xsl:variable name="prevsp">
+         <xsl:for-each select="preceding-sibling::text()">
+            <xsl:if test="position()=last()">
+               <xsl:value-of select="."/>
+            </xsl:if>
+         </xsl:for-each>
+      </xsl:variable>
+
+      <xsl:choose>
+         <xsl:when test="contains($prevsp,$cr)">
+            <xsl:call-template name="afterLastCR">
+               <xsl:with-param name="text" select="$prevsp"/>
+            </xsl:call-template>
+         </xsl:when>
+         <xsl:when test="$prevsp">
+            <xsl:value-of select="$prevsp"/>
+         </xsl:when>
+         <xsl:otherwise><xsl:text>    </xsl:text></xsl:otherwise>
+      </xsl:choose>
+   </xsl:template>
+
+   <!--
+     -  return the text that appears after the last carriage return
+     -  in the input text
+     -  @param text  the input text to process
+     -->
+   <xsl:template name="afterLastCR">
+      <xsl:param name="text"/>
+      <xsl:choose>
+         <xsl:when test="contains($text,$cr)">
+            <xsl:call-template name="afterLastCR">
+               <xsl:with-param name="text" select="substring-after($text,$cr)"/>
+            </xsl:call-template>
+         </xsl:when>
+         <xsl:otherwise><xsl:value-of select="$text"/></xsl:otherwise>
+      </xsl:choose>
+   </xsl:template>
+
+   <!--
+     -  indent the given number of levels.  The amount of indentation will 
+     -  be nlev times the value of the global $indent.
+     -  @param nlev   the number of indentations to insert.
+     -  @param sp     the string representing the per-indentation space;
+     -                  defaults to the value of $indent
+     -->
+   <xsl:template name="doindent">
+      <xsl:param name="nlev" select="2"/>
+      <xsl:param name="sp" select="$indent"/>
+
+      <xsl:if test="$nlev &gt; 0">
+         <xsl:value-of select="$sp"/>
+         <xsl:if test="$nlev &gt; 1">
+            <xsl:call-template name="doindent">
+               <xsl:with-param name="nlev" select="$nlev - 1"/>
+               <xsl:with-param name="sp" select="$sp"/>
+            </xsl:call-template>
+         </xsl:if>
+      </xsl:if>
+   </xsl:template>
+
+   <!--
+     -  convert all input characters to lower case
+     -  @param in  the string to convert
+     -->
+   <xsl:template name="lower">
+      <xsl:param name="in"/>
+      <xsl:value-of select="translate($in,
+                                      'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+                                      'abcdefghijklmnopqrstuvwxyz')"/>
+   </xsl:template>
+
+   <!--
+     -  convert the first character to an upper case
+     -  @param in  the string to convert
+     -->
+   <xsl:template name="capitalize">
+      <xsl:param name="in"/>
+      <xsl:value-of select="translate(substring($in,1,1),
+                                      'abcdefghijklmnopqrstuvwxyz',
+                                      'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"/>
+      <xsl:value-of select="substring($in,2)"/>
+   </xsl:template>
+
+   <!--
+     -  convert all input characters to lower case and then capitalize
+     -  @param in  the string to convert
+     -->
+   <xsl:template name="lowerandcap">
+      <xsl:param name="in"/>
+      <xsl:call-template name="capitalize">
+         <xsl:with-param name="in">
+            <xsl:call-template name="lower">
+               <xsl:with-param name="in" select="$in"/>
+            </xsl:call-template>
+         </xsl:with-param>
+      </xsl:call-template>
+   </xsl:template>
+
+   <!--
+     -  measure the indentation inside a node
+     -  @param text   a text node containing the indentation
+     -->
+   <xsl:template name="measIndent">
+      <xsl:param name="text"/>
+
+      <xsl:variable name="indnt">
+         <xsl:call-template name="afterLastCR">
+            <xsl:with-param name="text" select="$text"/>
+         </xsl:call-template>
+      </xsl:variable>
+
+      <xsl:value-of select="string-length($indnt)"/>
+   </xsl:template>
+
+   <!--
+     -  attempt to return the extra indentation applied to children 
+     -    of the current context node.  If a positive indentation cannot
+     -    be returned, return the default indentation.
+     -->
+   <xsl:template match="*" mode="getIndentStep">
+      <xsl:variable name="prevind">
+         <xsl:call-template name="measIndent">
+            <xsl:with-param name="text">
+               <xsl:call-template name="getindent"/>
+            </xsl:with-param>
+         </xsl:call-template>
+      </xsl:variable>
+      <xsl:variable name="childind">
+         <xsl:call-template name="measIndent">
+            <xsl:with-param name="text">
+               <xsl:for-each select="*[1]">
+                  <xsl:call-template name="getindent"/>
+               </xsl:for-each>
+            </xsl:with-param>
+         </xsl:call-template>
+      </xsl:variable>
+      <xsl:variable name="diff" select="$childind - $prevind"/>
+
+      <xsl:choose>
+         <xsl:when test="number($childind) &gt; number($prevind) and 
+                         number($prevind) &gt; 0">
+            <xsl:call-template name="doindent">
+               <xsl:with-param name="nlev" select="$diff"/>
+               <xsl:with-param name="sp" select="' '"/>
+            </xsl:call-template>
+         </xsl:when>
+         <xsl:otherwise><xsl:value-of select="$indent"/></xsl:otherwise>
+      </xsl:choose>
+   </xsl:template>
+
+   <xsl:template match="*" mode="flipName">
+      <xsl:variable name="split">
+         <xsl:call-template name="splitname">
+            <xsl:with-param name="name" select="."/>
+            <xsl:with-param name="marker" select="']['"/>
+         </xsl:call-template>
+      </xsl:variable>
+
+      <xsl:value-of select="substring-after($split,'][')"/>
+      <xsl:value-of select="', '"/>
+      <xsl:value-of select="substring-before($split,'][')"/>
+   </xsl:template>
+
+   <xsl:template name="lastword">
+      <xsl:param name="text"/>
+      <xsl:param name="delim" select="' '"/>
+
+      <xsl:variable name="txt" select="normalize-space($text)"/>
+
+      <xsl:choose>
+         <xsl:when test="contains($txt, $delim)">
+            <xsl:call-template name="lastword">
+               <xsl:with-param name="text"
+                               select="substring-after($txt, $delim)"/>
+               <xsl:with-param name="delim" select="$delim"/>
+            </xsl:call-template>
+         </xsl:when>
+         <xsl:otherwise><xsl:value-of select="$txt"/></xsl:otherwise>
+      </xsl:choose>
+   </xsl:template>
+
+   <xsl:template name="countwords">
+      <xsl:param name="text"/>
+      <xsl:param name="delim" select="' '"/>
+      <xsl:param name="count" select="0"/>
+
+      <xsl:variable name="txt" select="normalize-spaces($text)"/>
+
+      <xsl:choose>
+         <xsl:when test="contains($txt, $delim)">
+            <xsl:call-template name="lastword">
+               <xsl:with-param name="text"
+                               select="substring-after($txt, $delim)"/>
+               <xsl:with-param name="delim" select="$delim"/>
+               <xsl:with-param name="count" select="$count+1"/>
+            </xsl:call-template>
+         </xsl:when>
+         <xsl:otherwise><xsl:value-of select="$count"/></xsl:otherwise>
+      </xsl:choose>
+   </xsl:template>
+
+   <xsl:template name="splitname">
+      <xsl:param name="name"/>
+      <xsl:param name="sur"/>
+      <xsl:param name="delim" select="' '"/>
+      <xsl:param name="marker" select="']['" />
+
+      <xsl:variable name="fn" select="normalize-space($name)"/>
+      <xsl:variable name="ln" select="normalize-space($sur)"/>
+
+      <xsl:choose>
+         <xsl:when test="contains($fn, $delim)">
+           <xsl:variable name="back">
+              <xsl:call-template name="lastword">
+                 <xsl:with-param name="text" select="$fn"/>
+              </xsl:call-template>
+           </xsl:variable>
+
+           <xsl:choose>
+              <xsl:when test="string-length($ln)=0">
+                 <xsl:call-template name="splitname">
+                    <xsl:with-param name="name"
+                                    select="substring-before($fn, 
+                                                         concat($delim,$back))"/>
+                    <xsl:with-param name="sur" select="$back"/>
+                    <xsl:with-param name="delim" select="$delim"/>
+                    <xsl:with-param name="marker" select="$marker"/>
+                 </xsl:call-template>
+              </xsl:when>
+              <xsl:when test="contains('abcdefghijklmnopqrstuvwxyz',
+                                       substring($back,1,1))">
+                 <!-- last word preceded by non-capitalized word; include
+                      it as part of the last name -->
+                 <xsl:call-template name="splitname">
+                    <xsl:with-param name="name"
+                                    select="substring-before($fn, 
+                                                         concat($delim,$back))"/>
+                    <xsl:with-param name="sur"
+                                    select="concat($back,$delim,$ln)"/>
+                    <xsl:with-param name="delim" select="$delim"/>
+                    <xsl:with-param name="marker" select="$marker"/>
+                 </xsl:call-template>
+              </xsl:when>
+              <xsl:otherwise>
+                 <xsl:value-of select="concat($fn,$marker,$ln)"/>
+              </xsl:otherwise>
+           </xsl:choose>
+         </xsl:when>
+         <xsl:when test="string-length($ln)=0">
+            <xsl:value-of select="concat($marker,$fn)"/>
+         </xsl:when>
+         <xsl:otherwise>
+            <xsl:value-of select="concat($fn,$marker,$ln)"/>
+         </xsl:otherwise>
+      </xsl:choose>
+   </xsl:template>
+
+   <xsl:template match="*" mode="getidscheme">
+      <xsl:variable name="id" select="normalize-space(.)"/>
+      <xsl:choose>
+         <xsl:when test="starts-with($id,'doi:') or 
+                         starts-with($id,'http://doi.org/">DOI</xsl:when>
+         <xsl:when test="contains($id,'ark:') or 
+                         contains($id,'ARK:')">ARK</xsl:when>
+         <xsl:when test="starts-with($id,'orcid:') or 
+                         starts-with($id,'ORCID:') or 
+                         starts-with($id,'http://orchid.org/">ORCID</xsl:when>
+         <xsl:when test="starts-with($id,'isni:') or 
+                         starts-with($id,'ISNI:') or 
+                         contains($id,'isni.org/">ISNI</xsl:when>
+         <xsl:when test="starts-with($id,'hdl:') or 
+                         starts-with($id,'HDL:') or 
+                         contains($id,'handle.net/">HDL</xsl:when>
+         <xsl:when test="starts-with($id,'http:') or 
+                         starts-with($id,'https:')">URL</xsl:when>
+         <xsl:when test="starts-with($id,'ivo:')">IVOID</xsl:when>
+         <xsl:otherwise>unknown</xsl:otherwise>
+      </xsl:choose>
+   </xsl:template>
+
+   <xsl:template name="getiduri">
+      <xsl:param name="id"/>
+      <xsl:choose>
+         <xsl:when test="$id='HDL'">http://handle.net</xsl:when>
+         <xsl:when test="$id='DOI'">http://doi.org</xsl:when>
+         <xsl:when test="$id='ORCID'">http://orcid.org</xsl:when>
+         <xsl:when test="$id='ISNI'">http://www.isni.org</xsl:when>
+         <xsl:otherwise></xsl:otherwise>
+      </xsl:choose>
+   </xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
There are two significant updates related to resource types and to Datacite metadata.  

It is now possible to classify a resource as being of more than one type.  This category is captured in one or more `<role>` elements (each having a `<type>` child element giving the resource type name).  The `<role>` element is extensible, allowing type-specific metadata to be added.  Type names can either be controlled or arbitrary.

The schema has also been updated to be semantically aligned with the Datacite schema making it possible to generate a Datacite metadata record from the a resource record and vice versa.   (An XSL stylesheet for going from a resource record to datacite is included under `tools/xsl`.)  In particular, it leverages Datacite controlled vocabulary while allowing other vocabularies as well.  Some of the additions that were part of this are alternate titles, publication year, and relationships.
