### PR TITLE
fix mgi-json-schema.json for proper validation of enhanced schemas

### DIFF
--- a/schemas/json/mgi-json-schema.json
+++ b/schemas/json/mgi-json-schema.json
@@ -35,20 +35,30 @@
                     "type": "string",
                     "format": "uri",
                     "description": "An identifier for a metadata definition that this property is semantically equivalent"
-                },
-
-                "valueDocumentation": {
-                    "type": "object",
-                    "additionalProperties": {
-                        "$ref": "#/definitions/Documentation"
-                    },
-                    "description": "definitions of recognized string values for the property being defined",
-                    "notes": [
-                        "Each property name (within valueDocumentation) is an allowed value of the property being defined.  The values give the semantic meaning of the value.",
-                        "valueDescription can be used to define enumerated values; however, use of enum is not required.  Even when any value is allowed for the property, valueDocumentation can be used to define specially recognized values."
-                    ]
                 }
             }
+        },
+
+        "PropertyDocumentation": {
+            "description": "documentation specifically for an object property",
+            "allOf": [
+                { "$ref": "#/definitions/Documentation" },
+                {
+                    "properties": { 
+                        "valueDocumentation": {
+                            "type": "object",
+                            "additionalProperties": {
+                                "$ref": "#/definitions/Documentation"
+                            },
+                            "description": "definitions of recognized string values for the property being defined",
+                            "notes": [
+                                "Each property name (within valueDocumentation) is an allowed value of the property being defined.  The values give the semantic meaning of the value.",
+                                "valueDescription can be used to define enumerated values; however, use of enum is not required.  Even when any value is allowed for the property, valueDocumentation can be used to define specially recognized values."
+                            ]
+                        }
+                    }
+                } 
+            ]
         },
 
         "EnhancedSchemaArray": {
@@ -65,7 +75,7 @@
             "description": "JSON schema description with enhancements for documentation",
             "allOf": [
                 { "$ref": "http://json-schema.org/draft-04/schema#" },
-                { "$ref": "#/definitions/Documentation" },
+                { "$ref": "#/definitions/PropertyDocumentation" },
                 {
                     "properties": {
                         "$extensionSchemas": {
@@ -110,10 +120,13 @@
                         },
 
                         "dependencies": {
-                            "anyOf": [
-                                { "type": "boolean" },
-                                { "$ref": "#/definitions/EnhancedSchema" }
-                            ]
+                            "type": "object",
+                            "additionalProperties": { 
+                                "anyOf": [
+                                    { "$ref": "#/definitions/EnhancedSchema" },
+                                    { "$ref": "http://json-schema.org/draft-04/schema#/definitions/stringArray" }
+                                ]
+                            }
                         },
 
                         "items": {

--- a/schemas/json/mgi-json-schema.json
+++ b/schemas/json/mgi-json-schema.json
@@ -40,7 +40,7 @@
                 "valueDocumentation": {
                     "type": "object",
                     "additionalProperties": {
-                        "$ref": "#/defintions/Documentation"
+                        "$ref": "#/definitions/Documentation"
                     },
                     "description": "definitions of recognized string values for the property being defined",
                     "notes": [

--- a/schemas/json/mgi-json-schema.json
+++ b/schemas/json/mgi-json-schema.json
@@ -28,7 +28,7 @@
                     "description": "additional advice on the use of the thing being defined"
                 },
                 "comments": {
-                    "$ref": "#/defintions/Notes",
+                    "$ref": "#/definitions/Notes",
                     "description": "editorial comments not intended for user consumption"
                 },
                 "equivalentTo": {

--- a/schemas/json/mgi-json-schema.json
+++ b/schemas/json/mgi-json-schema.json
@@ -39,104 +39,88 @@
             }
         },
 
-        "EnhancedSchema": {
-            "type": "object",
-            "properties": {
-                "id": { "$ref": "http://json-schema.org/draft-04/schema#properties/id" },
-                "$schema": { "$ref": "http://json-schema.org/draft-04/schema#properties/$schema" },
-                "title": { "$ref": "http://json-schema.org/draft-04/schema#properties/title" },
-                "description": { "$ref": "http://json-schema.org/draft-04/schema#properties/description" },
-                "default": { "$ref": "http://json-schema.org/draft-04/schema#properties/default" },
-                "multipleOf": { "$ref": "http://json-schema.org/draft-04/schema#properties/multipleOf" },
-                "maximum": { "$ref": "http://json-schema.org/draft-04/schema#properties/maximum" },
-                "exclusiveMaximum": { "$ref": "http://json-schema.org/draft-04/schema#properties/exclusiveMaximum" },
-                "minimum": { "$ref": "http://json-schema.org/draft-04/schema#properties/minimum" },
-                "exclusiveMinimum": { "$ref": "http://json-schema.org/draft-04/schema#properties/exclusiveMinimum" },
-                "maxLength": { "$ref": "http://json-schema.org/draft-04/schema#properties/maxLength" },
-                "minLength": { "$ref": "http://json-schema.org/draft-04/schema#properties/minLength" },
-                "pattern": { "$ref": "http://json-schema.org/draft-04/schema#properties/pattern" },
-                "additionalItems": { "$ref": "http://json-schema.org/draft-04/schema#properties/additionalItems" },
-                "items": { "$ref": "http://json-schema.org/draft-04/schema#properties/items" },
-                "maxItems": { "$ref": "http://json-schema.org/draft-04/schema#properties/maxItems" },
-                "minItems": { "$ref": "http://json-schema.org/draft-04/schema#properties/minItems" },
-                "uniqueItems": { "$ref": "http://json-schema.org/draft-04/schema#properties/uniqueItems" },
-                "maxProperties": { "$ref": "http://json-schema.org/draft-04/schema#properties/maxProperties" },
-                "minProperties": { "$ref": "http://json-schema.org/draft-04/schema#properties/minProperties" },
-                "required": { "$ref": "http://json-schema.org/draft-04/schema#properties/required" },
-                "additionalProperties": { "$ref": "http://json-schema.org/draft-04/schema#properties/additionalProperties" },
-                "definitions": { "$ref": "http://json-schema.org/draft-04/schema#properties/definitions" },
-                "patternProperties": { "$ref": "http://json-schema.org/draft-04/schema#properties/patternProperties" },
-                "dependencies": { "$ref": "http://json-schema.org/draft-04/schema#properties/dependencies" },
-                "enum": { "$ref": "http://json-schema.org/draft-04/schema#properties/enum" },
-                "type": { "$ref": "http://json-schema.org/draft-04/schema#properties/type" },
-                "allOf": { "$ref": "http://json-schema.org/draft-04/schema#properties/allOf" },
-                "anyOf": { "$ref": "http://json-schema.org/draft-04/schema#properties/anyOf" },
-                "oneOf": { "$ref": "http://json-schema.org/draft-04/schema#properties/oneOf" },
-                "not": { "$ref": "http://json-schema.org/draft-04/schema#properties/not" },
-
-                "properties": {
-                    "allOf": [
-                        { "$ref": "http://json-schema.org/draft-04/schema#properties/properties" },
-                        { "properties": {
-                            "$extensionSchemas": {
-                                "type": "array",
-                                "items": {
-                                    "type": "string",
-                                    "format": "uri"
-                                },
-                                "description": "an array of identifiers that should be considered extensions of the schema given in the $schema property that instances of this schema are also compliant with.",
-                                "notes": [
-                                    "If an application recognizes any of the identifiers given, it can optionally choose to validate the instance against that schema and interpret and additional properties it defines accordingly.",
-                                    "It is recommended that the identifiers are ordered such that each refers to a schema that is an extension of those listed before it."
-                                ]
-                            },
-                            "notes": {
-                                "$ref": "#/definitions/Notes",
-                                "description": "additional advice on the use of the schema being defined"
-                            },
-                            "comments": {
-                                "$ref": "#/definitions/Notes",
-                                "description": "editorial comments not intended for user consumption"
-                            },
-                            "equivalentTo": {
-                                "type": "string",
-                                "format": "uri",
-                                "description": "An identifier for a metadata definition that this property is semantically equivalent"
-                            },
-                            "valueDocumentation": {
-                                "type": "object",
-                                "additionalProperties": {
-                                    "$ref": "#/defintions/Documentation"
-                                },
-                                "description": "definitions of recognized string values for the property being defined",
-                                "notes": [
-                                    "Each property name (within valueDocumentation) is an allowed value of the property being defined.  The values give the semantic meaning of the value.",
-                                    "valueDescription can be used to define enumerated values; however, use of enum is not required.  Even when any value is allowed for the property, valueDocumentation can be used to define specially recognized values."
-                                ]
-                            }
-                        }}
-                    ]
-                },
-
-                "notes": {
-                    "$ref": "#/definitions/Notes",
-                    "description": "additional advice on the use of the thing being defined"
-                },
-                "comments": {
-                    "$ref": "#/defintions/Notes",
-                    "description": "editorial comments not intended for user consumption"
-                },
-                "equivalentTo": {
-                    "type": "string",
-                    "format": "uri",
-                    "description": "An identifier for a metadata definition that this property is semantically equivalent"
+        "EnhancedSchemaArray": {
+            "description": "an array of enhanced schema definitions",
+            "allOf": [
+                { "$ref": "http://json-schema.org/draft-04/schema#/definitions/schemaArray" },
+                {
+                    "items": { "$ref": "#/definitions/EnhancedSchema" }
                 }
+            ]
+        },
 
-            }
+        "EnhancedSchema": {
+            "description": "JSON schema description with enhancements for documentation",
+            "allOf": [
+                { "$ref": "http://json-schema.org/draft-04/schema#" },
+                { "$ref": "#/definitions/Documentation" },
+                {
+                    "properties": {
+                        "$extensionSchemas": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "format": "uri"
+                            },
+                            "description": "an array of identifiers that should be considered extensions of the schema given in the $schema property that instances of this schema are also compliant with.",
+                            "notes": [
+                                "If an application recognizes any of the identifiers given, it can optionally choose to validate the instance against that schema and interpret and additional properties it defines accordingly.",
+                                "It is recommended that the identifiers are ordered such that each refers to a schema that is an extension of those listed before it."
+                            ],
+                            "default": [
+                                "http://mgi.nist.gov/mgi-json-schema/v0.1"
+                            ]
+                        },
+
+                        "definitions": {
+                            "additionalProperties": {
+                                "$ref": "#/definitions/EnhancedSchema"
+                            }
+                        },
+
+                        "properties": {
+                            "additionalProperties": {
+                                "$ref": "#/definitions/EnhancedSchema"
+                            }
+                        },
+
+                        "patternProperties": {
+                            "additionalProperties": {
+                                "$ref": "#/definitions/EnhancedSchema"
+                            }
+                        },
+
+                        "additionalProperties": {
+                            "anyOf": [
+                                { "type": "boolean" },
+                                { "$ref": "#/definitions/EnhancedSchema" }
+                            ]
+                        },
+
+                        "dependencies": {
+                            "anyOf": [
+                                { "type": "boolean" },
+                                { "$ref": "#/definitions/EnhancedSchema" }
+                            ]
+                        },
+
+                        "items": {
+                            "anyOf": [
+                                { "$ref": "#/definitions/EnhancedSchema" },
+                                { "$ref": "#/definitions/EnhancedSchemaArray" }
+                            ]
+                        },
+
+                        "allOf": { "$ref": "#/definitions/EnhancedSchemaArray" },
+                        "anyOf": { "$ref": "#/definitions/EnhancedSchemaArray" },
+                        "oneOf": { "$ref": "#/definitions/EnhancedSchemaArray" },
+                        "not": { "$ref": "#/definitions/EnhancedSchema" }
+
+                    }
+                }
+            ]
         }
     },
-    "allOf": [
-        { "$ref": "http://json-schema.org/draft-04/schema#" },
-        { "$ref": "#/definitions/EnhancedSchema" }
-    ]
+
+    "$ref": "#/definitions/EnhancedSchema" 
 }

--- a/schemas/json/mgi-json-schema.json
+++ b/schemas/json/mgi-json-schema.json
@@ -35,6 +35,18 @@
                     "type": "string",
                     "format": "uri",
                     "description": "An identifier for a metadata definition that this property is semantically equivalent"
+                },
+
+                "valueDocumentation": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "$ref": "#/defintions/Documentation"
+                    },
+                    "description": "definitions of recognized string values for the property being defined",
+                    "notes": [
+                        "Each property name (within valueDocumentation) is an allowed value of the property being defined.  The values give the semantic meaning of the value.",
+                        "valueDescription can be used to define enumerated values; however, use of enum is not required.  Even when any value is allowed for the property, valueDocumentation can be used to define specially recognized values."
+                    ]
                 }
             }
         },

--- a/tools/python/xjs/instance.py
+++ b/tools/python/xjs/instance.py
@@ -168,13 +168,13 @@ class Instance(object):
 
     def find_extended_objs(self):
         """
-        return a list of pointer-object tuples that contain a property having
-        the given name
+        return a list of pointer-object tuples that containing the 
+        "$extensionSchemas" property.
         
         This function is equivalent to 
-        self.find_obj_by_prop("$extendedSchemas").  That is, it returns all
+        self.find_obj_by_prop("$extensionSchemas").  That is, it returns all
         objects (including the root object, if applicable) that contains 
-        the "$exendedSchemas" property.  
+        the "$exensionSchemas" property.  
         """
         return self.find_obj_by_prop(EXTSCHEMAS)
 

--- a/tools/python/xjs/tests/test_validate.py
+++ b/tools/python/xjs/tests/test_validate.py
@@ -104,3 +104,27 @@ class TestExtValidator(object):
         with pytest.raises(val.ValidationError):
             validator.validate_file(probfile, False, True)
 
+    def test_loadschema(self, validator):
+        schema = {
+            "type": "object",
+            "properties": {
+                "name": { "type": "string" }
+            },
+            "id": "urn:gurn"
+        }
+        inst = { "name": "Bob" }
+        uri = "urn:goob"
+
+        assert uri not in validator._schemaStore
+        assert schema['id'] not in validator._schemaStore
+
+        validator.load_schema(schema, uri)
+        validator.validate_against(inst, [uri])
+
+        inst["name"] = 3
+        with pytest.raises(val.ValidationError):
+            validator.validate_against(inst, [uri])
+
+        inst["name"] = "bob"
+        validator.load_schema(schema)
+        validator.validate_against(inst, [schema['id']])

--- a/tools/python/xjs/tests/test_validateschema.py
+++ b/tools/python/xjs/tests/test_validateschema.py
@@ -57,7 +57,7 @@ def test_DocumentationType(validator):
         "description": "the def",
         "notes": [ "1", "2" ],
         "comments": [ "yes", "no" ],
-        "equivalentTo": "http://schema.org/email"
+        "equivalentTo": "http://schema.org/email",
     }
 
     validator.validate_against(inst, [schema['id']])
@@ -78,6 +78,56 @@ def test_DocumentationType(validator):
     with pytest.raises(val.ValidationError):
         validator.validate_against(inst, [schema['id']])
     inst["description"] = "the def"
+    validator.validate_against(inst, [schema['id']])
+
+    
+def test_PropDocumentationType(validator):
+    schema = schemashell.copy()
+    schema['$ref'] = "http://mgi.nist.gov/mgi-json-schema/v0.1#/definitions/PropertyDocumentation"
+    schema['id'] = "urn:propdoc"
+    validator.load_schema(schema)
+
+    inst = {
+        "description": "the def",
+        "notes": [ "1", "2" ],
+        "comments": [ "yes", "no" ],
+        "equivalentTo": "http://schema.org/email",
+        "valueDocumentation": {
+            "Funder": {
+                "description": "someone who funds the project",
+                "notes": [ "yes", "no" ]
+            },
+            "Manager": {
+                "description": "someone who manages the project",
+                "comments": [ "up", "down" ]
+            }
+        }
+    }
+
+    validator.validate_against(inst, [schema['id']])
+
+    inst["notes"] = "1, 2"
+    with pytest.raises(val.ValidationError):
+        validator.validate_against(inst, [schema['id']])
+    inst["notes"] = [ "1", "2" ]
+    validator.validate_against(inst, [schema['id']])
+
+    inst["comments"] = [ 1, 2 ]
+    with pytest.raises(val.ValidationError):
+        validator.validate_against(inst, [schema['id']])
+    inst["comments"] = [ "yes", "no" ]
+    validator.validate_against(inst, [schema['id']])
+
+    inst["description"] = [ "the def" ]
+    with pytest.raises(val.ValidationError):
+        validator.validate_against(inst, [schema['id']])
+    inst["description"] = "the def"
+    validator.validate_against(inst, [schema['id']])
+
+    inst["valueDocumentation"]["Manager"]["comments"] = [ 1, 2 ]
+    with pytest.raises(val.ValidationError):
+        validator.validate_against(inst, [schema['id']])
+    inst["valueDocumentation"]["Manager"]["comments"] = [ "1", "2" ]
     validator.validate_against(inst, [schema['id']])
 
     
@@ -105,4 +155,339 @@ def test_definitiondoc():
     schema['definitions']['Name']['notes'] = "yes, no" 
     with pytest.raises(val.ValidationError):
         validator.validate(schema, strict=True)
+    schema['definitions']['Name']['notes'] = [ "yes", "no" ]
+    schema['definitions']['Name']['valueDocumentation'] = {
+        "@God": {
+            "description": "refers to the one deity",
+            "notes": [ "not to be confused with Eric Clapton" ]
+        }
+    }
+    validator.validate(schema, strict=True)
+    schema['definitions']['Name']['valueDocumentation']['@God']['notes'] = \
+        "not to be confused with Eric Clapton"
+    with pytest.raises(val.ValidationError):
+        validator.validate(schema, strict=True)
+    
+def test_propdoc():
+    schema = schemashell.copy();
+    validator = val.ExtValidator.with_schema_dir(schemadir)
+
+    schema['type'] = "object"
+    schema['properties'] = {
+        "name": {
+            "type": "string",
+            "notes": [ "yes", "no" ]
+        }
+    }
+    validator.validate(schema, strict=True)
+    schema['properties']['name']['notes'] = "yes, no" 
+    with pytest.raises(val.ValidationError):
+        validator.validate(schema, strict=True)
+    schema['properties']['name']['notes'] = [ "yes", "no" ]
+
+    schema["definitions"] = {
+        "Organization": {
+            "type": "object",
+            "properties": {
+                "title": {
+                    "type": "string",
+                    "notes": [ "not too long, please" ]
+                }
+            }
+        }
+    }
+    validator.validate(schema, strict=True)
+    schema["definitions"]["Organization"]["properties"]["notes"] = 5
+    with pytest.raises(val.ValidationError):
+        validator.validate(schema, strict=True)
+    
+def test_addpropdoc():
+    schema = schemashell.copy();
+    validator = val.ExtValidator.with_schema_dir(schemadir)
+
+    schema['type'] = "object"
+    schema['additionalProperties'] = {
+        "type": "string",
+        "notes": [ "not too long, please" ]
+    }
+    validator.validate(schema, strict=True)
+    schema["additionalProperties"]["notes"] = 5
+    with pytest.raises(val.ValidationError):
+        validator.validate(schema, strict=True)
+    schema["additionalProperties"]["notes"] = [ "hey" ]
+    
+    schema["definitions"] = {
+        "Organization": {
+            "type": "object",
+            "additionalProperties": {
+                "type": "string",
+                "notes": [ "not too long, please" ]
+            }
+        }
+    }
+    validator.validate(schema, strict=True)
+    schema["definitions"]["Organization"]["additionalProperties"]["notes"] = 5
+    with pytest.raises(val.ValidationError):
+        validator.validate(schema, strict=True)
+    
+    
+def test_patpropdoc():
+    schema = schemashell.copy();
+    validator = val.ExtValidator.with_schema_dir(schemadir)
+
+    schema['type'] = "object"
+    schema['patternProperties'] = {
+        "proto_.*": {
+            "type": "string",
+            "notes": [ "not too long, please" ]
+        }
+    }
+    validator.validate(schema, strict=True)
+    schema["patternProperties"]["proto_.*"]["notes"] = 5
+    with pytest.raises(val.ValidationError):
+        validator.validate(schema, strict=True)
+    schema["patternProperties"]["proto_.*"]["notes"] = [ "hey" ]
+    
+    schema["definitions"] = {
+        "Organization": {
+            "type": "object",
+            "patternProperties": {
+                "neo_.*": {
+                    "type": "string",
+                    "notes": [ "not too long, please" ]
+                }
+            }
+        }
+    }
+    validator.validate(schema, strict=True)
+    schema["definitions"]["Organization"]["patternProperties"]["neo_.*"]["notes"] = 5
+    with pytest.raises(val.ValidationError):
+        validator.validate(schema, strict=True)
+    
+    
+def test_depdoc():
+    schema = schemashell.copy();
+    validator = val.ExtValidator.with_schema_dir(schemadir)
+
+    schema['type'] = "object"
+    schema['properties'] = {
+        "name": {
+            "type": "string",
+            "notes": [ "not too long, please" ]
+        },
+        "number": {
+            "type": "string",
+        }
+    }
+    schema["dependencies"] = {
+        "name": {
+            "notes": [ "a name requires a number" ],
+            "required": ["number"]
+        }
+    }
+    validator.validate(schema, strict=True)
+    schema["dependencies"]["name"]["notes"] = 5
+    with pytest.raises(val.ValidationError):
+        validator.validate(schema, strict=True)
+    schema["dependencies"]["name"]["notes"] = [ "hey" ]
+    
+    schema["definitions"] = {
+        "Organization": {
+            "type": "object",
+            "properties": {
+                "@id": {
+                    "type": "string",
+                    "notes": [ "not too long, please" ],
+                    "format": "uri"
+                },
+                "@type": {
+                    "type": "array"
+                }
+            },
+            "dependencies": {
+                "@id": {
+                    "notes": [ "wow" ],
+                    "properties": {
+                        "@type": { "minLength": 2 }
+                    }
+                }
+            }
+        }
+    }
+    validator.validate(schema, strict=True)
+    schema["definitions"]["Organization"]["dependencies"]["@id"]["notes"] = 5
+    with pytest.raises(val.ValidationError):
+        validator.validate(schema, strict=True)
+    
+    
+def test_allofdoc():
+    schema = schemashell.copy();
+    validator = val.ExtValidator.with_schema_dir(schemadir)
+
+    schema["allOf"] = [
+        {
+            "type": "object",
+            "notes": [ "when you need a string" ]
+        },
+        {
+            "notes": [ "like and extension" ],
+            "properties": {
+                "flavor": { "type": "string" }
+            }
+        }
+    ]
+
+    validator.validate(schema, strict=True)
+    schema["allOf"][1]["notes"] = 5
+    with pytest.raises(val.ValidationError):
+        validator.validate(schema, strict=True)
+    schema["allOf"][1]["notes"] = [ "hey" ]
+    validator.validate(schema, strict=True)
+    
+    schema["definitions"] = {
+        "Organization": {
+            "allOf": [
+                {
+                    "type": "array",
+                    "notes": [ "base" ]
+                },
+                {
+                    "maxLength": 5
+                }
+            ]
+        }
+    }
+
+    validator.validate(schema, strict=True)
+    schema["definitions"]["Organization"]["allOf"][0]["notes"] = 5
+    with pytest.raises(val.ValidationError):
+        validator.validate(schema, strict=True)
+    schema["definitions"]["Organization"]["allOf"][0]["notes"] = [ "hey" ]
+    validator.validate(schema, strict=True)
+    
+def test_anyofdoc():
+    schema = schemashell.copy();
+    validator = val.ExtValidator.with_schema_dir(schemadir)
+
+    schema["anyOf"] = [
+        {
+            "type": "integer",
+            "notes": [ "when you need a number" ]
+        },
+        {
+            "notes": [ "like and extension" ],
+            "type": "object",
+            "properties": {
+                "flavor": { "type": "string" }
+            }
+        }
+    ]
+
+    validator.validate(schema, strict=True)
+    schema["anyOf"][1]["notes"] = 5
+    with pytest.raises(val.ValidationError):
+        validator.validate(schema, strict=True)
+    schema["anyOf"][1]["notes"] = [ "hey" ]
+    validator.validate(schema, strict=True)
+    
+    schema["definitions"] = {
+        "Organization": {
+            "anyOf": [
+                {
+                    "type": "array",
+                    "notes": [ "base" ],
+                    "maxLength": 5
+                },
+                {
+                    "type": "string"
+                }
+            ]
+        }
+    }
+
+    validator.validate(schema, strict=True)
+    schema["definitions"]["Organization"]["anyOf"][0]["notes"] = 5
+    with pytest.raises(val.ValidationError):
+        validator.validate(schema, strict=True)
+    schema["definitions"]["Organization"]["anyOf"][0]["notes"] = [ "hey" ]
+    validator.validate(schema, strict=True)
+    
+def test_oneofdoc():
+    schema = schemashell.copy();
+    validator = val.ExtValidator.with_schema_dir(schemadir)
+
+    schema["oneOf"] = [
+        {
+            "type": "integer",
+            "notes": [ "when you need a number" ]
+        },
+        {
+            "notes": [ "like and extension" ],
+            "type": "object",
+            "properties": {
+                "flavor": { "type": "string" }
+            }
+        }
+    ]
+
+    validator.validate(schema, strict=True)
+    schema["oneOf"][1]["notes"] = 5
+    with pytest.raises(val.ValidationError):
+        validator.validate(schema, strict=True)
+    schema["oneOf"][1]["notes"] = [ "hey" ]
+    validator.validate(schema, strict=True)
+    
+    schema["definitions"] = {
+        "Organization": {
+            "oneOf": [
+                {
+                    "type": "array",
+                    "notes": [ "base" ],
+                    "maxLength": 5
+                },
+                {
+                    "type": "string"
+                }
+            ]
+        }
+    }
+
+    validator.validate(schema, strict=True)
+    schema["definitions"]["Organization"]["oneOf"][0]["notes"] = 5
+    with pytest.raises(val.ValidationError):
+        validator.validate(schema, strict=True)
+    schema["definitions"]["Organization"]["oneOf"][0]["notes"] = [ "hey" ]
+    validator.validate(schema, strict=True)
+    
+def test_notdoc():
+    schema = schemashell.copy();
+    validator = val.ExtValidator.with_schema_dir(schemadir)
+
+    schema["not"] = {
+        "type": "integer",
+        "notes": [ "when you can't have a number" ]
+    }
+
+    validator.validate(schema, strict=True)
+    schema["not"]["notes"] = 5
+    with pytest.raises(val.ValidationError):
+        validator.validate(schema, strict=True)
+    schema["not"]["notes"] = [ "hey" ]
+    validator.validate(schema, strict=True)
+    
+    schema["definitions"] = {
+        "Organization": {
+            "not": {
+                "type": "array",
+                "notes": [ "base" ],
+            }
+        }
+    }
+
+    validator.validate(schema, strict=True)
+    schema["definitions"]["Organization"]["not"]["notes"] = 5
+    with pytest.raises(val.ValidationError):
+        validator.validate(schema, strict=True)
+    schema["definitions"]["Organization"]["not"]["notes"] = [ "hey" ]
+    validator.validate(schema, strict=True)
     

--- a/tools/python/xjs/tests/test_validateschema.py
+++ b/tools/python/xjs/tests/test_validateschema.py
@@ -1,0 +1,108 @@
+"""
+This suite tests the validation of schemas that use the enhanced documentation.
+"""
+# import pytest
+from __future__ import with_statement
+import json, os, pytest, shutil
+import jsonschema as jsch
+from cStringIO import StringIO
+
+from . import Tempfiles
+import xjs.validate as val
+import xjs.schemaloader as loader
+
+schemadir = os.path.join(
+   os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))),
+                        "schemas", "json")
+mgi_json_schema = os.path.join(schemadir, "mgi-json-schema.json")
+datadir = os.path.join(os.path.dirname(__file__), "data")
+
+@pytest.fixture(scope="module")
+def validator(request):
+    return val.ExtValidator.with_schema_dir(schemadir)
+
+schemashell = {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "$extensionSchemas": [ "http://mgi.nist.gov/mgi-json-schema/v0.1" ],
+    "id": "urn:goob"
+}
+
+def test_NotesType(validator):
+    schema = schemashell.copy()
+    schema['id'] = "urn:notes"
+    schema["type"] = "object"
+    schema["properties"] = {
+        "sayings": {
+            "$ref": "http://mgi.nist.gov/mgi-json-schema/v0.1#/definitions/Notes"
+        }
+    }
+    validator.load_schema(schema)
+
+    inst = {
+        "sayings": [ "Hello", "world" ]
+    }
+    validator.validate_against(inst, [schema['id']])
+
+    inst['sayings'] = "Hello"
+    with pytest.raises(val.ValidationError):
+        validator.validate_against(inst, [schema['id']])
+    
+def test_DocumentationType(validator):
+    schema = schemashell.copy()
+    schema['$ref'] = "http://mgi.nist.gov/mgi-json-schema/v0.1#/definitions/Documentation"
+    schema['id'] = "urn:doc"
+    validator.load_schema(schema)
+
+    inst = {
+        "description": "the def",
+        "notes": [ "1", "2" ],
+        "comments": [ "yes", "no" ],
+        "equivalentTo": "http://schema.org/email"
+    }
+
+    validator.validate_against(inst, [schema['id']])
+
+    inst["notes"] = "1, 2"
+    with pytest.raises(val.ValidationError):
+        validator.validate_against(inst, [schema['id']])
+    inst["notes"] = [ "1", "2" ]
+    validator.validate_against(inst, [schema['id']])
+
+    inst["comments"] = [ 1, 2 ]
+    with pytest.raises(val.ValidationError):
+        validator.validate_against(inst, [schema['id']])
+    inst["comments"] = [ "yes", "no" ]
+    validator.validate_against(inst, [schema['id']])
+
+    inst["description"] = [ "the def" ]
+    with pytest.raises(val.ValidationError):
+        validator.validate_against(inst, [schema['id']])
+    inst["description"] = "the def"
+    validator.validate_against(inst, [schema['id']])
+
+    
+def test_topdoc():
+    schema = schemashell.copy();
+    validator = val.ExtValidator.with_schema_dir(schemadir)
+
+    schema['notes'] = [ "yes", "no" ]
+    validator.validate(schema, strict=True)
+    schema['notes'] = "yes, no" 
+    with pytest.raises(val.ValidationError):
+        validator.validate(schema, strict=True)
+    
+def test_definitiondoc():
+    schema = schemashell.copy();
+    validator = val.ExtValidator.with_schema_dir(schemadir)
+
+    schema['definitions'] = {
+        "Name": {
+            "type": "string",
+            "notes": [ "yes", "no" ]
+        }
+    }
+    validator.validate(schema, strict=True)
+    schema['definitions']['Name']['notes'] = "yes, no" 
+    with pytest.raises(val.ValidationError):
+        validator.validate(schema, strict=True)
+    

--- a/tools/python/xjs/validate.py
+++ b/tools/python/xjs/validate.py
@@ -50,6 +50,30 @@ class ExtValidator(object):
         """
         return ExtValidator(loader.SchemaLoader.from_directory(dirpath))
 
+    def load_schema(self, schema, uri=None):
+        """
+        load a pre-parsed schema into the validator.  The schema will be checked 
+        for errors first and raise an exception if there is a problem.  If schema
+        with the given ID was already loaded, it will get overriden.  
+
+        :argument dict schema:  the parsed schema object.
+        :argument str  uri:     The URI to associated with the schema.  If not 
+                                 provided, the value of the "id" property will
+                                 be used.  
+        """
+        if not uri:
+            uri = schema.get('id')
+        if not uri:
+            raise ValueError("No id property found; set uri param instead.")
+
+        # check the schema
+        vcls = jsch.validator_for(schema)
+        vcls.check_schema(schema)
+
+        # now add it
+        self._schemaStore[uri] = schema
+        
+        
     def validate(self, instance, minimally=False, strict=False, schemauri=None):
         """
         validate the instance document against its schema and its extensions


### PR DESCRIPTION
This PR redefines mgi-json-schema.json, the extension of the JSON Schema schema for enhanced documentation.  The previous version was not properly forcing the check of the use of extended documentation terms.  
