### PR TITLE
Fold in name changes based on feedback and revamp access

### DIFF
--- a/examples/xml/fipy-test.xml
+++ b/examples/xml/fipy-test.xml
@@ -6,22 +6,22 @@
           xmlns:rac="http://schema.nist.gov/xml/resmd-access/1.0wd" 
           xmlns:ms="http://schema.nist.gov/xml/mat-sci_res-md/1.0wd" 
           xsi:schemaLocation="http://schema.nist.gov/xml/res-md/1.0wd
-                              https://raw.githubusercontent.com/RayPlante/mgi-resmd/resmdxml.9/schemas/xml/res-md.xsd
+                              https://raw.githubusercontent.com/usnistgov/mgi-resmd/master/schemas/xml/res-md.xsd
                               http://schema.nist.gov/xml/resmd-datacite/1.0wd
-                              https://raw.githubusercontent.com/RayPlante/mgi-resmd/resmdxml.9/schemas/xml/resmd-datacite.xsd
+                              https://raw.githubusercontent.com/usnistgov/mgi-resmd/master/schemas/xml/resmd-datacite.xsd
                               http://schema.nist.gov/xml/resmd-access/1.0wd
-                              https://raw.githubusercontent.com/RayPlante/mgi-resmd/resmdxml.9/schemas/xml/resmd-access.xsd
+                              https://raw.githubusercontent.com/usnistgov/mgi-resmd/master/schemas/xml/resmd-access.xsd
                               http://schema.nist.gov/xml/mat-sci_res-md/1.0wd
-                              https://raw.githubusercontent.com/RayPlante/mgi-resmd/resmdxml.9/schemas/xml/mat-sci_res-md.xsd"
+                              https://raw.githubusercontent.com/usnistgov/mgi-resmd/master/schemas/xml/mat-sci_res-md.xsd"
           status="active" localid="urn:nist.gov/nmrr/ipr">
 
    <identity>
      <title> FiPy: A Finite Volume PDE Solver Using Python </title>
-     <shortName> FiPy </shortName>
+     <altTitle type="Abbreviation"> FiPy </altTitle>
      <version>3.1.1</version>
    </identity>
 
-   <curation>
+   <providers>
      <publisher> 
        NIST/MSED Center for Theoretical and Computational Materials Science (CTCMS) 
      </publisher>
@@ -43,7 +43,7 @@
        <name>Jonathan Guyer</name>
        <emailAddress> jonathan.guyer@nist.gov </emailAddress>
      </contact>
-   </curation>
+   </providers>
 
    <content>
      <description>
@@ -67,15 +67,15 @@
      </description>
      <subject> partial differential equations </subject>
      <subject> computational materials science </subject>
-     <referenceURL>
+     <landingPage>
        http://www.ctcms.nist.gov/fipy/
-     </referenceURL>
-     <referenceCitation pid="doi:10.1109/MCSE.2009.52">
+     </landingPage>
+     <reference pid="doi:10.1109/MCSE.2009.52">
        J. E. Guyer, D. Wheeler &amp; J. A. Warren, "FiPy: Partial
        Differential Equations with Python," Computing in Science &amp;
        Engineering 11(3) pp. 6—15 (2009), doi:10.1109/MCSE.2009.52,
        http://www.ctcms.nist.gov/fipy
-     </referenceCitation>
+     </reference>
      <primaryAudience> research </primaryAudience>
    </content>
 
@@ -99,23 +99,23 @@
    <!-- This part describes how to access it. -->
    <access>
      <policy>
-       <rights> public </rights>
-       <terms> http://www.ctcms.nist.gov/fipy/LICENSE.html </terms>
+       <restriction> public </restriction>
+       <termsURL> http://www.ctcms.nist.gov/fipy/LICENSE.html </termsURL>
      </policy>
-     <viaDownload>
+     <via xsi:type="rac:ViaDownload">
        <accessURL use="dir" returns="text/html">
           http://www.ctcms.nist.gov/fipy/download/
        </accessURL>
-     </viaDownload>
-     <via xsi:type="rac:AccessViaWeb" pid="">
-       <role>
+     </via>
+     <via xsi:type="rac:ViaPortal" pid="">
+       <title> FiPy Home page </title>
+       <description> </description>
+       <accessURL> http://www.ctcms.nist.gov/fipy/ </accessURL>
+       <details>
          <type pid="http://purl.org/dc/dcmitype/InteractiveResource">
            InteractiveResource: Portal
          </type>
-       </role>
-       <title> FiPy Home page </title>
-       <description> </description>
-       <homeURL> http://www.ctcms.nist.gov/fipy/ </homeURL>
+       </details>
      </via>
    </access>
 </Resource>

--- a/examples/xml/fipy.xml
+++ b/examples/xml/fipy.xml
@@ -6,22 +6,22 @@
           xmlns:rac="http://schema.nist.gov/xml/resmd-access/1.0wd" 
           xmlns:ms="http://schema.nist.gov/xml/mat-sci_res-md/1.0wd"
           xsi:schemaLocation="http://schema.nist.gov/xml/res-md/1.0wd
-                              https://raw.githubusercontent.com/RayPlante/mgi-resmd/resmdxml.9/schemas/xml/res-md.xsd
+                              https://raw.githubusercontent.com/usnistgov/mgi-resmd/master/schemas/xml/res-md.xsd
                               http://schema.nist.gov/xml/resmd-datacite/1.0wd
-                              https://raw.githubusercontent.com/RayPlante/mgi-resmd/resmdxml.9/schemas/xml/resmd-datacite.xsd
+                              https://raw.githubusercontent.com/usnistgov/mgi-resmd/master/schemas/xml/resmd-datacite.xsd
                               http://schema.nist.gov/xml/resmd-access/1.0wd
-                              https://raw.githubusercontent.com/RayPlante/mgi-resmd/resmdxml.9/schemas/xml/resmd-access.xsd
+                              https://raw.githubusercontent.com/usnistgov/mgi-resmd/master/schemas/xml/resmd-access.xsd
                               http://schema.nist.gov/xml/mat-sci_res-md/1.0wd
-                              https://raw.githubusercontent.com/RayPlante/mgi-resmd/resmdxml.9/schemas/xml/mat-sci_res-md.xsd"
+                              https://raw.githubusercontent.com/usnistgov/mgi-resmd/master/schemas/xml/mat-sci_res-md.xsd"
           status="active" localid="urn:nist.gov/nmrr/ipr">
 
    <identity>
      <title> FiPy: A Finite Volume PDE Solver Using Python </title>
-     <shortName> FiPy </shortName>
+     <altTitle type="Abbreviation"> FiPy </altTitle>
      <version>3.1.1</version>
    </identity>
 
-   <curation>
+   <providers>
      <publisher> 
        NIST/MSED Center for Theoretical and Computational Materials Science (CTCMS) 
      </publisher>
@@ -43,7 +43,7 @@
        <name>Jonathan Guyer</name>
        <emailAddress> jonathan.guyer@nist.gov </emailAddress>
      </contact>
-   </curation>
+   </providers>
 
    <content>
      <description>
@@ -67,27 +67,28 @@
      </description>
      <subject> partial differential equations </subject>
      <subject> computational materials science </subject>
-     <referenceURL>
+     <landingPage>
        http://www.ctcms.nist.gov/fipy/
-     </referenceURL>
-     <referenceCitation pid="doi:10.1109/MCSE.2009.52">
+     </landingPage>
+     <reference pid="doi:10.1109/MCSE.2009.52">
        J. E. Guyer, D. Wheeler &amp; J. A. Warren, "FiPy: Partial
        Differential Equations with Python," Computing in Science &amp;
        Engineering 11(3) pp. 6—15 (2009), doi:10.1109/MCSE.2009.52,
        http://www.ctcms.nist.gov/fipy
-     </referenceCitation>
+     </reference>
      <primaryAudience> research </primaryAudience>
    </content>
 
    <!-- This part contains Software-specific metadata -->
    <role xsi:type="rac:Software">
      <type> Software </type>
+     <!--
      <supportedOS> Mac OS X </supportedOS>
      <supportedOS> Debian Linux </supportedOS>
      <supportedOS> Ubuntu Linux </supportedOS>
      <supportedOS> Windows XP </supportedOS>
+         ... --> 
      <codeLanguage> Python </codeLanguage>
-     <!-- ... --> 
    </role>
 
    <!-- This part contains Materials Science-specific metadata -->
@@ -99,13 +100,13 @@
    <!-- This part describes how to access the software. -->
    <access>
      <policy>
-       <rights> public </rights>
-       <terms> http://www.ctcms.nist.gov/fipy/LICENSE.html </terms>
+       <restriction> public </restriction>
+       <termsURL> http://www.ctcms.nist.gov/fipy/LICENSE.html </termsURL>
      </policy>
-     <viaDownload>
+     <via xsi:type="rac:ViaDownload">
        <accessURL use="dir" returns="text/html">
           http://www.ctcms.nist.gov/fipy/download/
        </accessURL>
-     </viaDownload>
+     </via>
    </access>
 </Resource>

--- a/examples/xml/fipy.xml
+++ b/examples/xml/fipy.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Resource xmlns="" xsi:type="rac:AccessibleResource"
+<rsm:Resource xmlns="" xsi:type="rac:AccessibleResource"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xmlns:rsm="http://schema.nist.gov/xml/res-md/1.0wd"
           xmlns:dcr="http://schema.nist.gov/xml/resmd-datacite/1.0wd" 
@@ -109,4 +109,4 @@
        </accessURL>
      </via>
    </access>
-</Resource>
+</rsm:Resource>

--- a/examples/xml/ipr-test.xml
+++ b/examples/xml/ipr-test.xml
@@ -18,11 +18,11 @@
    <identity>
      <title>The Interatomic Potentials Repository Project</title>
      <altTitle type="AlternativeTitle">The Interatomic Potentials Repository Project</altTitle>
-     <shortName> IPR </shortName>
+     <altTitle type="Abbreviation"> IPR </altTitle>
      <version> 2.0 </version>
      <identifier>ark:asdlf13871</identifier>
    </identity>
-   <curation>
+   <providers>
      <publisher> 
        NIST/MSED Center for Theoretical and Computational Materials Science (CTCMS) 
      </publisher>
@@ -45,7 +45,7 @@
        <emailAddress> zachary.trautt@nist.gov </emailAddress>
        <timeZone> -0500 </timeZone>
      </contact>
-   </curation>
+   </providers>
    <content>
      <description>
        This repository provides a source for interatomic potentials
@@ -69,15 +69,15 @@
      <subject> metals </subject>
      <subject> force fields </subject>
      <subject> atomistic simulations </subject>
-     <referenceURL>
+     <landingPage>
        http://www.ctcms.nist.gov/potentials/
-     </referenceURL>
-     <referenceCitation pid="doi:10.1016/j.cossms.2013.10.001">
+     </landingPage>
+     <reference pid="doi:10.1016/j.cossms.2013.10.001">
        Becker, C.A. et al., "Considerations for choosing and using force 
        fields and interatomic potentials in materials science and 
        engineering," Current Opinion in Solid State and Materials Science, 
        17, 277-283 (2013).
-     </referenceCitation>
+     </reference>
      <primaryAudience> research </primaryAudience>
    </content>
    <role>
@@ -94,10 +94,10 @@
      <resource>IPR Help Page</resource>
    </related>
    <access>
-     <policy><rights> public </rights></policy>
-     <via xsi:type="rac:AccessViaWeb">
-       <role> <type> InteractiveResource: Portal </type></role>
-       <homeURL> http://www.ctcms.nist.gov/potentials/ </homeURL>
+     <policy><restriction> public </restriction></policy>
+     <via xsi:type="rac:ViaPortal">
+       <accessURL> http://www.ctcms.nist.gov/potentials/ </accessURL>
+       <details> <type> InteractiveResource: Portal </type></details>
      </via>
    </access>
 

--- a/examples/xml/ipr.xml
+++ b/examples/xml/ipr.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Resource xmlns="" xsi:type="rac:AccessibleResource"
+<rsm:Resource xmlns="" xsi:type="rac:AccessibleResource"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xmlns:rsm="http://schema.nist.gov/xml/res-md/1.0wd"
           xmlns:dcr="http://schema.nist.gov/xml/resmd-datacite/1.0wd" 
@@ -82,4 +82,4 @@
      <policy><restriction> public </restriction></policy>
    </access>
 
-</Resource>
+</rsm:Resource>

--- a/examples/xml/ipr.xml
+++ b/examples/xml/ipr.xml
@@ -5,22 +5,23 @@
           xmlns:dcr="http://schema.nist.gov/xml/resmd-datacite/1.0wd" 
           xmlns:rac="http://schema.nist.gov/xml/resmd-access/1.0wd" 
           xmlns:ms="http://schema.nist.gov/xml/mat-sci_res-md/1.0wd" 
+          xmlns:roth="http://schema.nist.gov/xml/resmd-otherroles/1.0wd" 
           xsi:schemaLocation="http://schema.nist.gov/xml/res-md/1.0wd
-                              https://raw.githubusercontent.com/RayPlante/mgi-resmd/resmdxml.9/schemas/xml/res-md.xsd
+                              https://raw.githubusercontent.com/usnistgov/mgi-resmd/master/schemas/xml/res-md.xsd
                               http://schema.nist.gov/xml/resmd-datacite/1.0wd
-                              https://raw.githubusercontent.com/RayPlante/mgi-resmd/resmdxml.9/schemas/xml/resmd-datacite.xsd
+                              https://raw.githubusercontent.com/usnistgov/mgi-resmd/master/schemas/xml/resmd-datacite.xsd
                               http://schema.nist.gov/xml/resmd-access/1.0wd
-                              https://raw.githubusercontent.com/RayPlante/mgi-resmd/resmdxml.9/schemas/xml/resmd-access.xsd
+                              https://raw.githubusercontent.com/usnistgov/mgi-resmd/master/schemas/xml/resmd-access.xsd
                               http://schema.nist.gov/xml/mat-sci_res-md/1.0wd
-                              https://raw.githubusercontent.com/RayPlante/mgi-resmd/resmdxml.9/schemas/xml/mat-sci_res-md.xsd"
+                              https://raw.githubusercontent.com/usnistgov/mgi-resmd/master/schemas/xml/mat-sci_res-md.xsd"
           status="active" localid="urn:nist.gov/nmrr/ipr">
 
    <identity>
      <title>The Interatomic Potentials Repository Project</title>
-     <shortName> IPR </shortName>
+     <altTitle type="Abbreviation"> IPR </altTitle>
      <version>2.0</version>
    </identity>
-   <curation>
+   <providers>
      <publisher> 
        NIST/MSED Center for Theoretical and Computational Materials Science (CTCMS) 
      </publisher>
@@ -37,7 +38,7 @@
        <emailAddress> zachary.trautt@nist.gov </emailAddress>
        <timeZone> -0500 </timeZone>
      </contact>
-   </curation>
+   </providers>
    <content>
      <description>
        This repository provides a source for interatomic potentials
@@ -58,19 +59,19 @@
      <subject> metals </subject>
      <subject> force fields </subject>
      <subject> atomistic simulations </subject>
-     <referenceURL>
+     <landingPage>
        http://www.ctcms.nist.gov/potentials/
-     </referenceURL>
-     <referenceCitation pid="doi:10.1016/j.cossms.2013.10.001">
+     </landingPage>
+     <reference pid="doi:10.1016/j.cossms.2013.10.001">
        Becker, C.A. et al., "Considerations for choosing and using force 
        fields and interatomic potentials in materials science and 
        engineering," Current Opinion in Solid State and Materials Science, 
        17, 277-283 (2013).
-     </referenceCitation>
+     </reference>
      <primaryAudience> research </primaryAudience>
    </content>
-   <role>
-      <type> Repository </type>
+   <role xsi:type="roth:Repository">
+      <type> Collection: Repository </type>
    </role>
    <applicability xsi:type="ms:MaterialsScience">
      <materialType> non-specific </materialType>
@@ -78,11 +79,7 @@
      <propertyClass> structural </propertyClass>
    </applicability>
    <access>
-     <policy><rights> public </rights></policy>
-     <via xsi:type="rac:AccessViaWeb">
-       <role> <type> InteractiveResource: Portal </type></role>
-       <homeURL> http://www.ctcms.nist.gov/potentials/ </homeURL>
-     </via>
+     <policy><restriction> public </restriction></policy>
    </access>
 
 </Resource>

--- a/examples/xml/nist-gasphase.xml
+++ b/examples/xml/nist-gasphase.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Resource xmlns="" xsi:type="rac:AccessibleResource"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns:rsm="http://schema.nist.gov/xml/res-md/1.0wd"
+          xmlns:dcr="http://schema.nist.gov/xml/resmd-datacite/1.0wd" 
+          xmlns:rac="http://schema.nist.gov/xml/resmd-access/1.0wd" 
+          xmlns:roth="http://schema.nist.gov/xml/resmd-otherroles/1.0wd" 
+          xmlns:ms="http://schema.nist.gov/xml/mat-sci_res-md/1.0wd"
+          xsi:schemaLocation="http://schema.nist.gov/xml/res-md/1.0wd
+                              https://raw.githubusercontent.com/usnistgov/mgi-resmd/master/schemas/xml/res-md.xsd
+                              http://schema.nist.gov/xml/resmd-datacite/1.0wd
+                              https://raw.githubusercontent.com/usnistgov/mgi-resmd/master/schemas/xml/resmd-datacite.xsd
+                              http://schema.nist.gov/xml/resmd-access/1.0wd
+                              https://raw.githubusercontent.com/usnistgov/mgi-resmd/master/schemas/xml/resmd-access.xsd
+                              http://schema.nist.gov/xml/mat-sci_res-md/1.0wd
+                              https://raw.githubusercontent.com/usnistgov/mgi-resmd/master/schemas/xml/mat-sci_res-md.xsd"
+          status="active" localid="urn:nist.gov/nmrr/ipr">
+
+   <identity>
+     <title>NIST/EPA Gas Phase Infrared Library</title>
+     <altTitle type="Subtitle">NIST Standard Reference Database #35</altTitle>
+     <altTitle type="Abbreviation">NIST-GPID</altTitle>
+     <altTitle type="Abbreviation">SRD#35</altTitle>
+     <identifier>doi:10.18434/T45K5N</identifier>
+   </identity>
+
+   <providers>
+     <publisher>US National Institute of Standards and Technology (NIST)</publisher>
+     <publicationYear> 2014 </publicationYear>
+
+     <creator>
+       <name>Carol Clifton</name>
+       <affiliation>NIST</affiliation>
+     </creator>
+     <creator>
+       <name>Jean Gallagher</name>
+       <affiliation>NIST</affiliation>
+     </creator>
+     <creator>
+       <name>Abdullah Shamin</name>
+       <affiliation>NIST</affiliation>
+     </creator>
+     <creator>
+       <name>Stephen Stein</name>
+       <affiliation>NIST</affiliation>
+     </creator>
+     <creator>
+       <name>Hussein Zohdi</name>
+       <affiliation>NIST</affiliation>
+     </creator>
+
+     <contact>
+       <name>Stephen Stein</name>
+       <emailAddress>steve.stein@nist.gov</emailAddress>
+       <timeZone> -0500 </timeZone>
+     </contact>
+   </providers>
+   <content>
+
+     <description>
+       This data collection contains 5,228 infrared spectra of different
+       compounds along with chemical structures for most of them. Spectra are
+       provided on a CD-ROM in the JCAMP-DX (Joint Committee for Atomic and
+       Molecular Physical Data "Data Exchange") format. Chemical structures are
+       provided in the MOL-file format. The IR data originated from two sources,
+       from the so-called "EPA Vapor-Phase IR Library" and from NIST
+       laboratories. The data have been sub-divided in two ways: 1) as
+       concatenated JCAMP and SDF files (concatenated MOL-files) and 2) in
+       individual files where each spectrum and structure is provided in a
+       separate JCAMP and MOL file, using file names containing the CAS registry
+       number of the compound. 
+     </description>
+     <description>
+       The data originally derived from the EPA Vapor-Phase IR Library itself
+       (3,108 spectra) and the spectra measured at NIST (2,120 spectra) are
+       provided in separate directories. All spectra are given as normalized
+       absorbance and empirical formulas and CAS Registry Numbers are given for
+       all compounds. About 80% of these compounds (and nearly all in the NIST
+       collection) have mass spectra included in the NIST/EPA/NIH Mass Spectral
+       Database. 
+     </description>
+     <subject>infrared spectra</subject>
+     <subject>vapor phase</subject>
+     <landingPage>http://dx.doi.org/10.18434/T45K5N</landingPage>
+     <primaryAudience> research </primaryAudience>
+   </content>
+   <role xsi:type="roth:Database">
+      <type> Dataset: Database </type>
+   </role>
+
+   <applicability xsi:type="ms:MaterialsScience">
+     <propertyClass> optical </propertyClass>
+   </applicability>
+
+   <access>
+     <policy>
+       <restriction> fee-required </restriction>
+       <termsURL>http://www.nist.gov/open/license.cfm</termsURL>
+     </policy>
+     <via xsi:type="rac:ViaMedia">
+       <description>CDROM contains 5228 spectra in JCAMP-DX format</description>
+       <accessURL>http://dx.doi.org/10.18434/T45K5N</accessURL>
+       <details><type>Physical Object: Storage Media</type></details>
+       <mediaType>CDROM</mediaType>
+     </via>
+   </access>
+
+</Resource>
+   

--- a/examples/xml/nist-gasphase.xml
+++ b/examples/xml/nist-gasphase.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<Resource xmlns="" xsi:type="rac:AccessibleResource"
+<rsm:Resource xmlns="" xsi:type="rac:AccessibleResource"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xmlns:rsm="http://schema.nist.gov/xml/res-md/1.0wd"
           xmlns:dcr="http://schema.nist.gov/xml/resmd-datacite/1.0wd" 
@@ -105,5 +105,5 @@
      </via>
    </access>
 
-</Resource>
+</rsm:Resource>
    

--- a/examples/xml/schemaLocation.txt
+++ b/examples/xml/schemaLocation.txt
@@ -3,5 +3,6 @@ http://www.openarchives.org/OAI/2.0/oai_dc/ ../../schemas/xml/extern/oai_dc-v2.0
 http://schema.nist.gov/xml/res-md/1.0wd ../../schemas/xml/res-md.xsd
 http://schema.nist.gov/xml/resmd-datacite/1.0wd ../../schemas/xml/resmd-datacite.xsd
 http://schema.nist.gov/xml/resmd-access/1.0wd ../../schemas/xml/resmd-access.xsd
+http://schema.nist.gov/xml/resmd-otherroles/1.0wd ../../schemas/xml/resmd-otherroles.xsd
 http://schema.nist.gov/xml/mat-sci_res-md/1.0wd ../../schemas/xml/mat-sci_res-md.xsd
 

--- a/schemas/xml/res-md.xsd
+++ b/schemas/xml/res-md.xsd
@@ -29,6 +29,16 @@
 
    <xs:import namespace="http://www.w3.org/XML/1998/namespace"
               schemaLocation="http://www.w3.org/2009/01/xml.xsd"/>
+
+   <xs:element name="Resource" type="rsm:Resource">
+      <xs:annotation>
+         <xs:documentation>
+           a root element for a document describing a Resource,
+           an identified, described, and discoverable component of the 
+           distributed data environment. 
+         </xs:documentation>
+      </xs:annotation>
+   </xs:element>
    
    <xs:complexType name="Resource">
       <xs:annotation>

--- a/schemas/xml/res-md.xsd
+++ b/schemas/xml/res-md.xsd
@@ -5,7 +5,7 @@
            xmlns:rsm="http://schema.nist.gov/xml/res-md/1.0wd" 
            xmlns:am="http://schema.nist.gov/xml/nmrr.schema.annot" 
            elementFormDefault="unqualified" 
-           attributeFormDefault="unqualified" version="0.9">
+           attributeFormDefault="unqualified" version="0.10">
 
    <xs:annotation>
       <xs:documentation>
@@ -55,7 +55,7 @@
             </xs:annotation>
          </xs:element>
 
-         <xs:element name="curation" type="rsm:Curation">
+         <xs:element name="providers" type="rsm:Providers">
            <xs:annotation>
              <xs:documentation>
                Information regarding the general curation of the resource
@@ -72,7 +72,7 @@
            </xs:annotation>
          </xs:element>
 
-         <xs:element name="role" type="rsm:Role"
+         <xs:element name="role" type="rsm:ResourceRole"
                      minOccurs="1" maxOccurs="unbounded">
            <xs:annotation>
              <xs:documentation>
@@ -205,24 +205,6 @@
             </xs:annotation>
          </xs:element>
 
-         <xs:element name="shortName" type="xs:token" minOccurs="0">
-            <xs:annotation>
-               <xs:documentation>
-                 a short name or abbreviation given to the resource.
-               </xs:documentation>
-               <xs:documentation>
-                 This name will be used where brief annotations for
-                 the resource name are required.  Applications may 
-                 use this to refer to this resource in a compact display.  
-                 This is NOT expected to be globally unique; thus, it 
-                 should not be used as an identifier.  
-               </xs:documentation>
-               <xs:documentation>
-                 One word or a few letters is recommended.  
-               </xs:documentation>
-            </xs:annotation>
-         </xs:element>
-
          <xs:element name="version" type="xs:token" minOccurs="0">
             <xs:annotation>
                <xs:documentation>
@@ -338,10 +320,31 @@
          </xs:annotation>
        </xs:enumeration>
          
+       <xs:enumeration value="Abbreviation">
+         <xs:annotation>
+           <xs:documentation>
+             title value represents an abbreviation of the title.
+           </xs:documentation>
+           <xs:documentation>
+             An abbreviation might be, for example, initials or an acronym.
+           </xs:documentation>
+           <xs:documentation>
+             This name will be used where brief annotations for
+             the resource name are required.  Applications may 
+             use this to refer to this resource in a compact display.  
+             This is NOT expected to be globally unique; thus, it 
+             should not be used as an identifier.  
+           </xs:documentation>
+           <xs:documentation>
+             One word or a few letters is recommended.  
+           </xs:documentation>
+         </xs:annotation>
+       </xs:enumeration>
+         
      </xs:restriction>
    </xs:simpleType>
         
-   <xs:complexType name="Curation">
+   <xs:complexType name="Providers">
      <xs:annotation>
        <xs:documentation>
          Information regarding the general curation of a resource
@@ -763,16 +766,17 @@
           </xs:annotation>
        </xs:element>
 
-       <xs:element name="referenceURL" type="xs:anyURI">
+       <xs:element name="landingPage" type="xs:anyURI">
           <xs:annotation>
-             <xs:documentation>
-                URL pointing to a human-readable document describing this 
-                resource.   
+            <xs:documentation>
+                URL pointing to the definitive, human-readable document or web
+                page that serves as the primary description of or entry to
+                this resource.
              </xs:documentation>
           </xs:annotation>
        </xs:element>
 
-       <xs:element name="referenceCitation" type="rsm:NamePID" 
+       <xs:element name="reference" type="rsm:NamePID" 
                    minOccurs="0" maxOccurs="unbounded">
           <xs:annotation>
              <xs:documentation>
@@ -785,6 +789,12 @@
                 an article bibliography).  The pid attribute gives a persistant 
                 or otherwise unambiguous identifier for the article; a DOI
                 is prefered.  
+             </xs:documentation>
+             <xs:documentation>
+               It is recommended that while multiple references can be given,
+               only those that provide the fullest or most direct descriptions
+               of this resource be listed (as opposed to simple mentions or
+               citations by derived works).
              </xs:documentation>
           </xs:annotation>
        </xs:element>
@@ -813,6 +823,10 @@
        <xs:documentation>
          a type for expressing a subject keyword that may be drawn from
          a standard set of keywords
+       </xs:documentation>
+       <xs:documentation>
+         Usually, when the pid attribute can be provided, it is usually not
+         necessary to provide values for scheme or schemaURI.  
        </xs:documentation>
      </xs:annotation>
 
@@ -888,7 +902,7 @@
      </xs:restriction>
    </xs:simpleType>
 
-   <xs:complexType name="Role">
+   <xs:complexType name="ResourceRole">
      <xs:annotation>
        <xs:documentation>
          metadata describing the resource's role as a resource of a particular

--- a/schemas/xml/resmd-access.xsd
+++ b/schemas/xml/resmd-access.xsd
@@ -6,7 +6,7 @@
            xmlns:rac="http://schema.nist.gov/xml/resmd-access/1.0wd" 
            xmlns:am="http://schema.nist.gov/xml/mgi.schema.annot" 
            elementFormDefault="unqualified" 
-           attributeFormDefault="unqualified" version="0.1">
+           attributeFormDefault="unqualified" version="0.2">
 
    <xs:annotation>
       <xs:documentation>
@@ -16,7 +16,7 @@
    </xs:annotation>
 
    <xs:import namespace="http://schema.nist.gov/xml/res-md/1.0wd"
-              schemaLocation="https://raw.githubusercontent.com/RayPlante/mgi-resmd/resmdxml.9/schemas/xml/res-md.xsd"/>
+              schemaLocation="https://raw.githubusercontent.com/usnistgov/mgi-resmd/master/schemas/xml/res-md.xsd"/>
 
    <xs:complexType name="AccessibleResource">
      <xs:annotation>
@@ -68,19 +68,6 @@
          </xs:annotation>
        </xs:element>
 
-       <xs:element name="viaDownload" type="rac:Download"
-                   minOccurs="0" maxOccurs="unbounded">
-         <xs:annotation>
-           <xs:documentation>
-             A description of URLs for directly downloading the
-             resource.
-           </xs:documentation>
-           <xs:documentation>
-             (only for data collections and software classes?)
-           </xs:documentation>
-         </xs:annotation>
-       </xs:element>
-
        <xs:element name="via" type="rac:AccessVia"
                    minOccurs="0" maxOccurs="unbounded">
          <xs:annotation>
@@ -111,38 +98,16 @@
      </xs:annotation>
 
      <xs:sequence>
-       <xs:element name="role" type="rsm:Role"
-                   minOccurs="0" maxOccurs="1">
-         <xs:annotation>
-           <xs:documentation>
-             An identification of the type of access mechanism this is along
-             with, if appropriate, qualifications on the features and
-             constraints on that mechanism.
-           </xs:documentation>
-           <xs:documentation>
-             The child type element provides the identifying label for the
-             access mechanism.  Recognized types include,
-             'InteractiveResource: Portal', 'Software', and 'Service: API'.
-           </xs:documentation>
-           <xs:documentation>
-             Sub-classes of Role can define additional metadata for describing
-             how it fulfills its role.  The xsi:type attribute must be used
-             to include this additional metadata.  
-           </xs:documentation>
-         </xs:annotation>
-       </xs:element>
-
        <xs:element name="title" type="xs:token"
                    minOccurs="0" maxOccurs="1">
          <xs:annotation>
            <xs:documentation>
-             A name for the access method.
+             A name for the access method or the thing accessed via the
+             accessURL.
            </xs:documentation>
            <xs:documentation>
-             Providing this title is recommended when the access mechanism is
-             distinct from this resource in some way; e.g. if it is a more
-             general platform than this resource, or it is maintained by a
-             a separate entity.
+             The value should be appropriate for use as the text for a
+             hyperlink pointing to the accessURL.
            </xs:documentation>
          </xs:annotation>
        </xs:element>
@@ -158,6 +123,36 @@
              </xs:documentation>
           </xs:annotation>
        </xs:element>
+
+       <xs:element name="accessURL" type="rac:AccessURL" minOccurs="0">
+          <xs:annotation>
+             <xs:documentation>
+               The URL that through which user can access the resource via
+               this method.
+             </xs:documentation>
+             <xs:documentation>
+               The behavior and role of this URL depends on the specific type
+               of access method.
+             </xs:documentation>
+          </xs:annotation>
+       </xs:element>       
+
+       <xs:element name="details" type="rsm:ResourceRole"
+                   minOccurs="0" maxOccurs="1">
+         <xs:annotation>
+           <xs:documentation>
+             An identification of the type of access mechanism this is along
+             with, if appropriate, qualifications on the features and
+             constraints on that mechanism.
+           </xs:documentation>
+           <xs:documentation>
+             The child type element provides the identifying label for the
+             access mechanism.  Recognized types include,
+             'InteractiveResource: Portal', 'Software', and 'Service: API'.
+           </xs:documentation>
+         </xs:annotation>
+       </xs:element>
+
      </xs:sequence>
 
      <xs:attribute name="pid" type="xs:anyURI">
@@ -178,35 +173,50 @@
      
    </xs:complexType>
 
-   <xs:complexType name="AccessViaWeb">
+   <xs:complexType name="DownloadDetailsType">
      <xs:annotation>
        <xs:documentation>
-         metadata describing how one can access a resource
+         a Role whose type is forced to be 'Download'.
+       </xs:documentation>
+       <xs:documentation>
+         This is only intended for use within an AccessVia subclass.
        </xs:documentation>
      </xs:annotation>
 
      <xs:complexContent>
-       <xs:extension base="rac:AccessVia">
+       <xs:restriction base="rsm:ResourceRole">
          <xs:sequence>
-
-           <xs:element name="homeURL" type="xs:anyURI" minOccurs="0">
-              <xs:annotation>
-                 <xs:documentation>
-                   URL for accessing (via a browser) the home or entrance
-                   page that provides access to the resource.
-                 </xs:documentation>
-                 <xs:documentation>
-                   This should be provided when the URL is different from
-                   the resource's referenceURL.
-                 </xs:documentation>
-              </xs:annotation>
-           </xs:element>       
-
+           <xs:element name="type" type="rsm:RoleType" minOccurs="1"
+                       fixed="Download"/>
          </xs:sequence>
-       </xs:extension>
+       </xs:restriction>
      </xs:complexContent>
+   </xs:complexType>
 
-     
+   <xs:complexType name="ViaDownload">
+     <xs:annotation>
+       <xs:documentation>
+         metadata describing how one can access a resource via the web
+       </xs:documentation>
+       <xs:documentation>
+         The accessURL is a URL that (when accessed via HTTP GET) will can be
+         used to download a file representing part or all of this resource.
+         (See also the use attribute which refines its behavior).  The
+         accessURL element is required.  
+       </xs:documentation>
+     </xs:annotation>
+
+     <xs:complexContent>
+       <xs:restriction base="rac:AccessVia">
+         <xs:sequence>
+           <xs:element name="title" type="xs:token" minOccurs="0" maxOccurs="1"/>
+           <xs:element name="description" type="xs:token" minOccurs="0"/>
+           <xs:element name="accessURL" type="rac:AccessURL" minOccurs="1"/>
+           <xs:element name="details" type="rac:DownloadDetailsType"
+                       minOccurs="0" maxOccurs="1"/>
+         </xs:sequence>
+       </xs:restriction>
+     </xs:complexContent>
    </xs:complexType>
 
    <xs:complexType name="Policy">
@@ -217,22 +227,38 @@
      </xs:annotation>
 
      <xs:sequence>
-       <xs:element name="rights" type="rac:Rights"
-                   minOccurs="1" maxOccurs="unbounded">
+       <xs:element name="restriction" type="rac:Restriction"
+                   minOccurs="1" maxOccurs="4">
+         <xs:annotation>
+           <xs:appinfo>
+             <am:dcterm>accessRights</am:dcterm>
+           </xs:appinfo>           
+           <xs:documentation>
+             A label indicating a restriction in accessing this resource.  
+           </xs:documentation>
+           <xs:documentation>
+             This should be repeated for all Restriction values that apply.
+           </xs:documentation>
+         </xs:annotation>
+       </xs:element>
+
+       <xs:element name="rights" type="xs:token" minOccurs="0" maxOccurs="1">
          <xs:annotation>
            <xs:appinfo>
              <am:dcterm>Rights</am:dcterm>
            </xs:appinfo>           
            <xs:documentation>
-             Information about the held in and over the resource.
+             A brief, user-friendly statement clarifying who may access this 
+             resource and under what conditions.
            </xs:documentation>
            <xs:documentation>
-             This should be repeated for all Rights values that apply.
+             Official legal statements giving the terms of use should be
+             provided via the termsURI element.
            </xs:documentation>
          </xs:annotation>
        </xs:element>
 
-       <xs:element name="terms" type="xs:anyURI" minOccurs="0" maxOccurs="1">
+       <xs:element name="termsURL" type="xs:anyURI" minOccurs="0" maxOccurs="1">
          <xs:annotation>
            <xs:appinfo>
              <am:dcterm>Rights</am:dcterm>
@@ -247,7 +273,7 @@
      </xs:sequence>
    </xs:complexType>
 
-   <xs:simpleType name="Rights">
+   <xs:simpleType name="Restriction">
       <xs:restriction base="xs:token">
          <xs:enumeration value="public">
             <xs:annotation>
@@ -285,41 +311,6 @@
          </xs:enumeration>
       </xs:restriction>
    </xs:simpleType>
-
-   <xs:complexType name="Download">
-     <xs:annotation>
-       <xs:documentation>
-         A description of how to download data or related files via simple
-         (HTTP GET) URLs.
-       </xs:documentation>
-     </xs:annotation>
-
-     <xs:sequence>
-       <xs:element name="description" type="xs:token" minOccurs="0">
-          <xs:annotation>
-             <xs:documentation>
-               A summary of what the download URL delivers
-             </xs:documentation>
-             <xs:documentation>
-               Providing a description is recommended if more than one
-               portal is available.  If the accessURL's use attribute is set 
-               to "base", describe what is expected to be appended to the URL
-               to retrieve individual files.  
-             </xs:documentation>
-          </xs:annotation>
-       </xs:element>
-
-       <xs:element name="accessURL" type="rac:AccessURL">
-          <xs:annotation>
-             <xs:documentation>
-                The URL that, when accessed (via HTTP GET), will deliver the 
-                data or file associated with this resource.  
-             </xs:documentation>
-          </xs:annotation>
-       </xs:element>       
-     </xs:sequence>
-     
-   </xs:complexType>
 
    <xs:complexType name="AccessURL">
      <xs:simpleContent>
@@ -393,7 +384,7 @@
      </xs:annotation>
 
      <xs:complexContent>
-       <xs:restriction base="rsm:Role">
+       <xs:restriction base="rsm:ResourceRole">
          <xs:sequence>
            <xs:element name="type" type="rsm:RoleType" minOccurs="1"
                        fixed="Software">
@@ -436,6 +427,116 @@
 
    </xs:complexType>
 
+   <xs:complexType name="ViaSoftware">
+     <xs:annotation>
+       <xs:documentation>
+         metadata describing how one can access a resource via locally
+         installable software.
+       </xs:documentation>
+       <xs:documentation>
+         The accessURL points to the home page for the software from which it
+         can be downloaded.  
+       </xs:documentation>
+       <xs:documentation>
+         The details element provides additional information about supported
+         platforms, licensing, etc. 
+       </xs:documentation>
+     </xs:annotation>
+
+     <xs:complexContent>
+       <xs:restriction base="rac:AccessVia">
+         <xs:sequence>
+           <xs:element name="title" type="xs:token" minOccurs="0" maxOccurs="1"/>
+           <xs:element name="description" type="xs:token" minOccurs="0"/>
+           <xs:element name="accessURL" type="rac:AccessURL" minOccurs="0"/>
+           <xs:element name="details" type="rac:Software"
+                       minOccurs="0" maxOccurs="1"/>
+         </xs:sequence>
+       </xs:restriction>
+     </xs:complexContent>
+   </xs:complexType>
+
+   <xs:complexType name="MediaDetailsType">
+     <xs:annotation>
+       <xs:documentation>
+         a Role whose type is forced to be 'Media'.
+       </xs:documentation>
+       <xs:documentation>
+         This is only intended for use within an AccessVia subclass.
+       </xs:documentation>
+     </xs:annotation>
+
+     <xs:complexContent>
+       <xs:restriction base="rsm:ResourceRole">
+         <xs:sequence>
+           <xs:element name="type" type="rsm:RoleType" minOccurs="1"
+                       fixed="Physical Object: Storage Media">
+             <xs:annotation>
+               <xs:documentation>
+                 It is recommended that the pid attribute be set to
+                 http://purl.org/dc/dcmitype/PhysicalObject
+               </xs:documentation>
+             </xs:annotation>
+           </xs:element>             
+         </xs:sequence>
+       </xs:restriction>
+     </xs:complexContent>
+   </xs:complexType>
+
+   <xs:complexType name="ViaMediaRestriction" abstract="true">
+     <xs:annotation>
+     </xs:annotation>
+
+     <xs:complexContent>
+       <xs:restriction base="rac:AccessVia">
+         <xs:sequence>
+           <xs:element name="title" type="xs:token" minOccurs="0" maxOccurs="1"/>
+           <xs:element name="description" type="xs:token" minOccurs="0"/>
+           <xs:element name="accessURL" type="rac:AccessURL" minOccurs="0"/>
+           <xs:element name="details" type="rac:MediaDetailsType"
+                       minOccurs="1" maxOccurs="1"/>
+         </xs:sequence>
+       </xs:restriction>
+     </xs:complexContent>
+   </xs:complexType>
+
+   <xs:complexType name="ViaMedia">
+     <xs:annotation>
+       <xs:documentation>
+         A description of access to a resource via physical storage media
+       </xs:documentation>
+       <xs:documentation>
+         The accessURL points to a web page that describes how to request the
+         media.
+       </xs:documentation>
+     </xs:annotation>
+
+     <xs:complexContent>
+       <xs:extension base="rac:ViaMediaRestriction">
+         <xs:sequence>
+
+           <xs:element name="mediaType" type="xs:token"
+                       minOccurs="1" maxOccurs="unbounded">
+              <xs:annotation>
+                 <xs:documentation>
+                   The type of media provided
+                 </xs:documentation>
+                 <xs:documentation>
+                   Recommended values include "CDROM", "DVD", etc.
+                 </xs:documentation>
+             </xs:annotation>
+           </xs:element>
+            
+           <xs:element name="requestURL" type="xs:anyURI" minOccurs="0">
+              <xs:annotation>
+             </xs:annotation>
+           </xs:element>
+         
+         </xs:sequence>
+       </xs:extension>
+     </xs:complexContent>
+   </xs:complexType>
+
    <xs:complexType name="ServiceAPIRoleTypeRestriction" abstract="true">
      <xs:annotation>
        <xs:documentation>
@@ -444,7 +545,7 @@
      </xs:annotation>
 
      <xs:complexContent>
-       <xs:restriction base="rsm:Role">
+       <xs:restriction base="rsm:ResourceRole">
          <xs:sequence>
            <xs:element name="type" type="rsm:RoleType" minOccurs="1"
                        fixed="Service: API">
@@ -504,6 +605,105 @@
        </xs:extension>
      </xs:complexContent>
 
+   </xs:complexType>
+
+   <xs:complexType name="ViaServiceAPI">
+     <xs:annotation>
+       <xs:documentation>
+         metadata describing how one can access a resource via a web service
+         API 
+       </xs:documentation>
+       <xs:documentation>
+         The accessURL points to a documentation and/or GUI front-end to the 
+         service.  
+       </xs:documentation>
+       <xs:documentation>
+         The details element provides additional information about supported
+         platforms, licensing, etc. 
+       </xs:documentation>
+     </xs:annotation>
+
+     <xs:complexContent>
+       <xs:restriction base="rac:AccessVia">
+         <xs:sequence>
+           <xs:element name="title" type="xs:token" minOccurs="0" maxOccurs="1"/>
+           <xs:element name="description" type="xs:token" minOccurs="0"/>
+           <xs:element name="accessURL" type="rac:AccessURL" minOccurs="0"/>
+           <xs:element name="details" type="rac:Software"
+                       minOccurs="0" maxOccurs="1"/>
+         </xs:sequence>
+       </xs:restriction>
+     </xs:complexContent>
+   </xs:complexType>
+
+   <xs:complexType name="PortalRoleTypeRestriction" abstract="true">
+     <xs:annotation>
+       <xs:documentation>
+         a Role whose type is forced to be 'InteractiveResource: Portal'.
+       </xs:documentation>
+     </xs:annotation>
+
+     <xs:complexContent>
+       <xs:restriction base="rsm:ResourceRole">
+         <xs:sequence>
+           <xs:element name="type" type="rsm:RoleType" minOccurs="1"
+                       fixed="InteractiveResource: Portal">
+             <xs:annotation>
+               <xs:documentation>
+                 It is recommended that the pid attribute be set to
+                 http://purl.org/dc/dcmitype/Software
+               </xs:documentation>
+             </xs:annotation>
+           </xs:element>             
+         </xs:sequence>
+       </xs:restriction>
+     </xs:complexContent>
+   </xs:complexType>
+
+   <xs:complexType name="Portal">
+     <xs:annotation>
+       <xs:documentation>
+         metadata for describing a web portal, a web site that aggregrates and
+         provides interaction with data and browser-based tools.
+       </xs:documentation>
+     </xs:annotation>
+
+     <xs:complexContent>
+       <xs:extension base="rac:PortalRoleTypeRestriction">
+         <xs:sequence>
+
+         </xs:sequence>
+       </xs:extension>
+     </xs:complexContent>
+
+   </xs:complexType>
+
+   <xs:complexType name="ViaPortal">
+     <xs:annotation>
+       <xs:documentation>
+         description of acces to a resource via a portal.
+       </xs:documentation>
+       <xs:documentation>
+         The accessURL points to the landing page for the portal.
+       </xs:documentation>
+       <xs:documentation>
+         Use this AccessVia type when the resource is accessible via a portal
+         that is not specific to this resource.  In such a case the accessURL
+         given here would not be the same as the resource's landingPage URL.  
+       </xs:documentation>
+     </xs:annotation>
+
+     <xs:complexContent>
+       <xs:restriction base="rac:AccessVia">
+         <xs:sequence>
+           <xs:element name="title" type="xs:token" minOccurs="0" maxOccurs="1"/>
+           <xs:element name="description" type="xs:token" minOccurs="0"/>
+           <xs:element name="accessURL" type="rac:AccessURL" minOccurs="0"/>
+           <xs:element name="details" type="rac:Portal"
+                       minOccurs="0" maxOccurs="1"/>
+         </xs:sequence>
+       </xs:restriction>
+     </xs:complexContent>
    </xs:complexType>
 
 

--- a/schemas/xml/resmd-otherroles.xsd
+++ b/schemas/xml/resmd-otherroles.xsd
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema targetNamespace="http://schema.nist.gov/xml/resmd-otherroles/1.0wd" 
+           xmlns="http://www.w3.org/2001/XMLSchema" 
+           xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+           xmlns:rsm="http://schema.nist.gov/xml/res-md/1.0wd" 
+           xmlns:roth="http://schema.nist.gov/xml/resmd-otherroles/1.0wd" 
+           xmlns:am="http://schema.nist.gov/xml/mgi.schema.annot" 
+           elementFormDefault="unqualified" 
+           attributeFormDefault="unqualified" version="0.1">
+
+   <xs:annotation>
+      <xs:documentation>
+        An extension of the MGI resource metadata that defines simple resource
+        types that do not offer any extended role metadata.  
+      </xs:documentation>
+   </xs:annotation>
+
+   <xs:import namespace="http://schema.nist.gov/xml/res-md/1.0wd"
+              schemaLocation="https://raw.githubusercontent.com/usnistgov/mgi-resmd/master/schemas/xml/res-md.xsd"/>
+
+   <xs:complexType name="Repository">
+     <xs:annotation>
+       <xs:documentation>
+         a resource that aggregates and makes accessible many datasets together
+         as part of a collection.  
+       </xs:documentation>
+     </xs:annotation>
+
+     <xs:complexContent>
+       <xs:restriction base="rsm:ResourceRole">
+         <xs:sequence>
+           <xs:element name="type" type="rsm:RoleType" minOccurs="1"
+                       fixed="Collection: Repository">
+             <xs:annotation>
+               <xs:documentation>
+                 It is recommended that the pid attribute be set to
+                 http://purl.org/dc/dcmitype/Collection
+               </xs:documentation>
+             </xs:annotation>
+           </xs:element>             
+         </xs:sequence>
+       </xs:restriction>
+     </xs:complexContent>
+   </xs:complexType>
+
+   <xs:complexType name="Database">
+     <xs:annotation>
+       <xs:documentation>
+         a searchable collection of tabular or property-oriented data
+       </xs:documentation>
+     </xs:annotation>
+
+     <xs:complexContent>
+       <xs:restriction base="rsm:ResourceRole">
+         <xs:sequence>
+           <xs:element name="type" type="rsm:RoleType" minOccurs="1"
+                       fixed="Dataset: Database">
+             <xs:annotation>
+               <xs:documentation>
+                 It is recommended that the pid attribute be set to
+                 http://purl.org/dc/dcmitype/Dataset.  
+               </xs:documentation>
+             </xs:annotation>
+           </xs:element>             
+         </xs:sequence>
+       </xs:restriction>
+     </xs:complexContent>
+   </xs:complexType>
+
+</xs:schema>
+


### PR DESCRIPTION
This folds in some element name changes that reflect user feedback and consistency with other relevant schemas.  access is normalized a bit and expanded to additional roles and access methods. Some access methods can be referred to via identifier to separate resource or described in-line.  

