### PR TITLE
Add an annotated example

### DIFF
--- a/examples/xml/annotated-example.xml
+++ b/examples/xml/annotated-example.xml
@@ -36,12 +36,14 @@
 
    <!--
        This section indicates who is responsible for making this resource
-       available
+       available.  The publisher and various name elements can be
+       annotated with an identifier (via pid attribute).
      -->
    <providers>
      <publisher> 
        NIST/MSED Center for Theoretical and Computational Materials Science (CTCMS) 
      </publisher>
+     <publicationYear> 2011 </publicationYear>
 
      <creator>
        <name>Chandler Becker</name>
@@ -49,9 +51,11 @@
      </creator>
 
      <contributor role="DataCurator" xsi:type="dcr:DciteContributor">
-       <name>Zachary Trautt</name>
+       <name pid="orcid:0000-0001-5929-0354"> Zachary Trautt </name>
      </contributor>
 
+     <!-- Datacite date types:  Created, Accepted, Copyrighted,
+          Available, Collected, Issued, Submitted, Updated, Valid -->
      <date role="Created" xsi:type="dcr:DciteDate"> 2008-04-01 </date>
 
      <contact>
@@ -60,7 +64,13 @@
        <timeZone> -0500 </timeZone>
      </contact>
    </providers>
+
+   <!--
+       This section summarizes in general what this resource is about
+       and/or contains.
+     -->
    <content>
+
      <description>
        This repository provides a source for interatomic potentials
        (force fields), related files, and evaluation tools to help
@@ -75,32 +85,135 @@
        related files are currently available for various metals,
        semiconductors, oxides, and carbon-containing systems. 	  
      </description>
+
      <subject> interatomic potentials </subject>
      <subject> molecular dynamics </subject>
      <subject> metals </subject>
      <subject> force fields </subject>
      <subject> atomistic simulations </subject>
+
      <landingPage>
        http://www.ctcms.nist.gov/potentials/
      </landingPage>
+
      <reference pid="doi:10.1016/j.cossms.2013.10.001">
        Becker, C.A. et al., "Considerations for choosing and using force 
        fields and interatomic potentials in materials science and 
        engineering," Current Opinion in Solid State and Materials Science, 
        17, 277-283 (2013).
      </reference>
+
      <primaryAudience> research </primaryAudience>
    </content>
+
+   <!--
+       a resource can be of several types.  It's role as that type is
+       expressed as a <role> element, and some role types can have
+       additional metadata associated with them.  Software is an
+       example that would have extended metadata.
+     -->
    <role xsi:type="roth:Repository">
       <type> Collection: Repository </type>
    </role>
+
+   <role xsi:type="roth:Portal">
+      <type> Interactive Resource: Portal </type>
+   </role>
+
+   <!--
+       The applicability element provides 
+     -->
    <applicability xsi:type="ms:MaterialsScience">
-     <materialType> non-specific </materialType>
-     <propertyClass> simulated </propertyClass>
-     <propertyClass> structural </propertyClass>
+
+       <materialType xsi:type="mse:Ceramics_Material_type">
+         Ceramics: Perovskite
+       </materialType>
+
+       <structuralFeature xsi:type="mse:Composites_Structural_Feature">
+         Composites: nanocomposites
+       </structuralFeature>
+       <structuralFeature xsi:type="mse:Defects_Structural_Feature">
+         Defects: Point defects
+       </structuralFeature>
+       
+       <propertyAddressed xsi:type="mse:Microstructural_Properties_addressed">
+         Microstructural
+       </propertyAddressed>
+
+       <experimentalMethod xsi:type="mse:Charge_distribution_Experimental_Methods">
+         Charge distribution
+       </experimentalMethod>
+
+       <computationalMethod xsi:type="mse:Dislocation_Dynamics_Computational_Methods">
+         Dislocation Dynamics
+       </computationalMethod>
+
+       <synthesisProcessing xsi:type="mse:Annealing_Synthesis_and_Processing">
+         Annealing: normalizing
+       </synthesisProcessing>
+
    </applicability>
+
+   <!--
+       This section describes ways that the resource can be accessed. 
+     -->
    <access>
-     <policy><restriction> public </restriction></policy>
+
+     <policy>
+       <!-- keywords describing restrictions on access:
+            public, open-login, proprietary, fee-required -->
+       <restriction> public </restriction>
+       <restriction> proprietary </restriction>
+
+       <rights> Access to some data items require logins and authorization </rights>
+       <termsURL> https://www.nist.gov/director/licensing </termsURL>
+     </policy>
+
+     <!--
+         multiple <via> elements can describe different ways for accessing
+         a resource
+       -->
+     <via xsi:type="ViaPortal">
+       <title> The IPR Portal </title>
+       <description> ... </description>
+
+       <!-- if different from landing page -->
+       <accessURL> https://www.ctcms.nist.gov/potentials/search </accessURL>
+
+       <details><type> InteractiveResource: Portal </type></details>
+     </via>       
+
+     <!-- downloadable file or directory of files -->
+     <via xsi:type="ViaDownload">
+       <title> The IPR database </title>
+       <description> ... </description>
+       <accessURL> https://www.ctcms.nist.gov/potentials/data.json </accessURL>
+       <details><type> Download </type></details>
+       <format> text/json </format>
+       <filesize> 1100 </filesize>
+     </via>       
+
+     <!-- service API (that may conform to some standard) -->
+     <via xsi:type="ViaDownload">
+       <title> The IPR search service </title>
+       <description> ... </description>
+       <details><type> Service: API </type></details>
+       <baseURL> https://www.ctcms.nist.gov/potentials/api </baseURL>
+       <specificationURL> https://... </specificationURL>
+       <complianceID> https://... </complianceID>
+     </via>
+
+     <!-- via media one can order -->
+     <via xsi:type="ViaMedia">
+       <title> The IPR Database </title>
+       <description> ... </description>
+
+       <!-- if different from landing page -->
+       <accessURL> https://www.ctcms.nist.gov/potentials/order </accessURL>
+
+       <details><type> Physical Object: Storage Media </type></details>
+       <mediaType> CDROM </mediaType>
+     </via>       
    </access>
 
 </rsm:Resource>

--- a/examples/xml/annotated-example.xml
+++ b/examples/xml/annotated-example.xml
@@ -5,6 +5,7 @@
           xmlns:dcr="http://schema.nist.gov/xml/resmd-datacite/1.0wd" 
           xmlns:rac="http://schema.nist.gov/xml/resmd-access/1.0wd" 
           xmlns:ms="http://schema.nist.gov/xml/mat-sci_res-md/1.0wd" 
+          xmlns:mse="https://www.nist.gov/od/sch/mse-vocab/1.0wd" 
           xmlns:roth="http://schema.nist.gov/xml/resmd-otherroles/1.0wd" 
           xsi:schemaLocation="http://schema.nist.gov/xml/res-md/1.0wd
                               https://raw.githubusercontent.com/usnistgov/mgi-resmd/master/schemas/xml/res-md.xsd
@@ -25,7 +26,7 @@
 
       Title is required, all other fields are optional
     -->
-  <identity>
+   <identity>
      <title>The Interatomic Potentials Repository Project</title>
      <altTitle type="Subtitle"> Special Repository #3 </altTitle>
      <altTitle type="Abbreviation"> IPR </altTitle>
@@ -116,8 +117,8 @@
       <type> Collection: Repository </type>
    </role>
 
-   <role xsi:type="roth:Portal">
-      <type> Interactive Resource: Portal </type>
+   <role xsi:type="roth:Database">
+      <type> Dataset: Database </type>
    </role>
 
    <!--
@@ -144,7 +145,7 @@
          Charge distribution
        </experimentalMethod>
 
-       <computationalMethod xsi:type="mse:Dislocation_Dynamics_Computational_Methods">
+       <computationalMethod xsi:type="mse:Dislocation_Dynamics_Computational_method">
          Dislocation Dynamics
        </computationalMethod>
 
@@ -173,7 +174,7 @@
          multiple <via> elements can describe different ways for accessing
          a resource
        -->
-     <via xsi:type="ViaPortal">
+     <via xsi:type="rac:ViaPortal">
        <title> The IPR Portal </title>
        <description> ... </description>
 
@@ -184,7 +185,7 @@
      </via>       
 
      <!-- downloadable file or directory of files -->
-     <via xsi:type="ViaDownload">
+     <via xsi:type="rac:ViaDownload">
        <title> The IPR database </title>
        <description> ... </description>
        <accessURL> https://www.ctcms.nist.gov/potentials/data.json </accessURL>
@@ -194,17 +195,19 @@
      </via>       
 
      <!-- service API (that may conform to some standard) -->
-     <via xsi:type="ViaDownload">
+     <via xsi:type="rac:ViaServiceAPI">
        <title> The IPR search service </title>
        <description> ... </description>
-       <details><type> Service: API </type></details>
-       <baseURL> https://www.ctcms.nist.gov/potentials/api </baseURL>
-       <specificationURL> https://... </specificationURL>
-       <complianceID> https://... </complianceID>
+       <details>
+         <type> Service: API </type>
+         <baseURL> https://www.ctcms.nist.gov/potentials/api </baseURL>
+         <specificationURL> https://... </specificationURL>
+         <complianceID> https://... </complianceID>
+       </details>
      </via>
 
      <!-- via media one can order -->
-     <via xsi:type="ViaMedia">
+     <via xsi:type="rac:ViaMedia">
        <title> The IPR Database </title>
        <description> ... </description>
 

--- a/examples/xml/annotated-example.xml
+++ b/examples/xml/annotated-example.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rsm:Resource xmlns="" xsi:type="rac:AccessibleResource"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns:rsm="http://schema.nist.gov/xml/res-md/1.0wd"
+          xmlns:dcr="http://schema.nist.gov/xml/resmd-datacite/1.0wd" 
+          xmlns:rac="http://schema.nist.gov/xml/resmd-access/1.0wd" 
+          xmlns:ms="http://schema.nist.gov/xml/mat-sci_res-md/1.0wd" 
+          xmlns:roth="http://schema.nist.gov/xml/resmd-otherroles/1.0wd" 
+          xsi:schemaLocation="http://schema.nist.gov/xml/res-md/1.0wd
+                              https://raw.githubusercontent.com/usnistgov/mgi-resmd/master/schemas/xml/res-md.xsd
+                              http://schema.nist.gov/xml/resmd-datacite/1.0wd
+                              https://raw.githubusercontent.com/usnistgov/mgi-resmd/master/schemas/xml/resmd-datacite.xsd
+                              http://schema.nist.gov/xml/resmd-access/1.0wd
+                              https://raw.githubusercontent.com/usnistgov/mgi-resmd/master/schemas/xml/resmd-access.xsd
+                              http://schema.nist.gov/xml/mat-sci_res-md/1.0wd
+                              https://raw.githubusercontent.com/usnistgov/mgi-resmd/master/schemas/xml/mat-sci_res-md.xsd"
+          status="active" localid="urn:nist.gov/nmrr/ipr">
+
+  <!--
+      This section provides metadata related to how we name and refer to this
+      resource.
+
+      Note the localid attribute above is the identifier assigned by the
+      creating registry.
+
+      Title is required, all other fields are optional
+    -->
+  <identity>
+     <title>The Interatomic Potentials Repository Project</title>
+     <altTitle type="Subtitle"> Special Repository #3 </altTitle>
+     <altTitle type="Abbreviation"> IPR </altTitle>
+     <version>2.0</version>
+     <logo> https://www.ctcms.nist.gov/potentials/ipr.png </logo>
+   </identity>
+
+
+   <!--
+       This section indicates who is responsible for making this resource
+       available
+     -->
+   <providers>
+     <publisher> 
+       NIST/MSED Center for Theoretical and Computational Materials Science (CTCMS) 
+     </publisher>
+
+     <creator>
+       <name>Chandler Becker</name>
+       <affiliation> NIST </affiliation>
+     </creator>
+
+     <contributor role="DataCurator" xsi:type="dcr:DciteContributor">
+       <name>Zachary Trautt</name>
+     </contributor>
+
+     <date role="Created" xsi:type="dcr:DciteDate"> 2008-04-01 </date>
+
+     <contact>
+       <name>Zachary Trautt</name>
+       <emailAddress> zachary.trautt@nist.gov </emailAddress>
+       <timeZone> -0500 </timeZone>
+     </contact>
+   </providers>
+   <content>
+     <description>
+       This repository provides a source for interatomic potentials
+       (force fields), related files, and evaluation tools to help
+       researchers obtain interatomic models and judge their quality
+       and applicability. Users are encouraged to download and use
+       interatomic potentials, with proper acknowledgement, and
+       developers are welcome to contribute potentials for
+       inclusion. The files provided have been submitted or vetted by
+       their developers and appropriate references are provided. All
+       classes of potentials (e.g., MEAM, ADP, COMB, Reax, EAM, etc.)
+       and materials are welcome. Interatomic potentials and/or
+       related files are currently available for various metals,
+       semiconductors, oxides, and carbon-containing systems. 	  
+     </description>
+     <subject> interatomic potentials </subject>
+     <subject> molecular dynamics </subject>
+     <subject> metals </subject>
+     <subject> force fields </subject>
+     <subject> atomistic simulations </subject>
+     <landingPage>
+       http://www.ctcms.nist.gov/potentials/
+     </landingPage>
+     <reference pid="doi:10.1016/j.cossms.2013.10.001">
+       Becker, C.A. et al., "Considerations for choosing and using force 
+       fields and interatomic potentials in materials science and 
+       engineering," Current Opinion in Solid State and Materials Science, 
+       17, 277-283 (2013).
+     </reference>
+     <primaryAudience> research </primaryAudience>
+   </content>
+   <role xsi:type="roth:Repository">
+      <type> Collection: Repository </type>
+   </role>
+   <applicability xsi:type="ms:MaterialsScience">
+     <materialType> non-specific </materialType>
+     <propertyClass> simulated </propertyClass>
+     <propertyClass> structural </propertyClass>
+   </applicability>
+   <access>
+     <policy><restriction> public </restriction></policy>
+   </access>
+
+</rsm:Resource>

--- a/schemas/xml/resmd-access.xsd
+++ b/schemas/xml/resmd-access.xsd
@@ -193,6 +193,26 @@
      </xs:complexContent>
    </xs:complexType>
 
+   <xs:complexType name="ViaDownloadRestrict" abstract="true">
+     <xs:annotation>
+       <xs:documentation>
+         abstract type for restricting type to download
+       </xs:documentation>
+     </xs:annotation>
+
+     <xs:complexContent>
+       <xs:restriction base="rac:AccessVia">
+         <xs:sequence>
+           <xs:element name="title" type="xs:token" minOccurs="0" maxOccurs="1"/>
+           <xs:element name="description" type="xs:token" minOccurs="0"/>
+           <xs:element name="accessURL" type="rac:AccessURL" minOccurs="1"/>
+           <xs:element name="details" type="rac:DownloadDetailsType"
+                       minOccurs="0" maxOccurs="1"/>
+         </xs:sequence>
+       </xs:restriction>
+     </xs:complexContent>
+   </xs:complexType>
+
    <xs:complexType name="ViaDownload">
      <xs:annotation>
        <xs:documentation>
@@ -207,15 +227,32 @@
      </xs:annotation>
 
      <xs:complexContent>
-       <xs:restriction base="rac:AccessVia">
+       <xs:extension base="rac:ViaDownloadRestrict">
          <xs:sequence>
-           <xs:element name="title" type="xs:token" minOccurs="0" maxOccurs="1"/>
-           <xs:element name="description" type="xs:token" minOccurs="0"/>
-           <xs:element name="accessURL" type="rac:AccessURL" minOccurs="1"/>
-           <xs:element name="details" type="rac:DownloadDetailsType"
-                       minOccurs="0" maxOccurs="1"/>
+           <xs:element name="format" type="xs:token"
+                       minOccurs="0" maxOccurs="unbounded">
+             <xs:annotation>
+               <xs:documentation>
+                 The MIME type describing the format of the downloadable
+                 file or files.
+               </xs:documentation>
+             </xs:annotation>
+           </xs:element>
+           <xs:element name="filesize" type="xs:token" minOccurs="0">
+             <xs:annotation>
+               <xs:documentation>
+                 The maximum size of the downloadable file in measured
+                 in kilobytes.
+               </xs:documentation>
+               <xs:documentation>
+                 The actual size can be provided if this section
+                 describes only one file.  In either case, this value
+                 should be considered approximate.  
+               </xs:documentation>
+             </xs:annotation>
+           </xs:element>
          </xs:sequence>
-       </xs:restriction>
+       </xs:extension>
      </xs:complexContent>
    </xs:complexType>
 
@@ -629,7 +666,7 @@
            <xs:element name="title" type="xs:token" minOccurs="0" maxOccurs="1"/>
            <xs:element name="description" type="xs:token" minOccurs="0"/>
            <xs:element name="accessURL" type="rac:AccessURL" minOccurs="0"/>
-           <xs:element name="details" type="rac:Software"
+           <xs:element name="details" type="rac:ServiceAPI"
                        minOccurs="0" maxOccurs="1"/>
          </xs:sequence>
        </xs:restriction>


### PR DESCRIPTION
The annotated example shows (almost) all possible fields in a single record.  This demo required some fixes to `resmd-access.xsd`.